### PR TITLE
Never adopt a Postgres this project cannot prove is its own

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,10 +1,12 @@
 import os
 import shutil
 import textwrap
+import zlib
 from pathlib import Path
 
 CWD = Path.cwd().absolute()
 
+PROJECT_SLUG = "{{ cookiecutter.project_slug }}"
 DB_CHOICE = "{{ cookiecutter.database_choice }}"
 CI_CHOICE = "{{ cookiecutter.ci_choice }}"
 API_ONLY = "{{ cookiecutter.api_only }}" == "True"
@@ -23,6 +25,41 @@ def remove(*relpaths):
             shutil.rmtree(target)
         elif target.exists():
             target.unlink()
+
+
+# The band sits below every OS ephemeral range -- Linux allocates from 32768,
+# macOS from 49152 -- so a port reserved here is never one the kernel might
+# hand to something else first.
+EMBEDDED_PORT_BASE = 15432
+EMBEDDED_PORT_SPAN = 1000
+
+
+def assign_embedded_port():
+    """Give this project its own Postgres port, derived from its slug.
+
+    Every project sharing one default port meant two of them could not run at
+    once, and the second silently attached to the first's database instead of
+    starting its own.
+    """
+    if DB_CHOICE != "postgres":
+        return
+
+    port = EMBEDDED_PORT_BASE + zlib.crc32(PROJECT_SLUG.encode()) % EMBEDDED_PORT_SPAN
+    edits = {
+        ".env.example": ("EMBEDDED_POSTGRES_PORT=5433", f"EMBEDDED_POSTGRES_PORT={port}"),
+        "internal/config/config.go": (
+            "EMBEDDED_POSTGRES_PORT,default=5433",
+            f"EMBEDDED_POSTGRES_PORT,default={port}",
+        ),
+        "Taskfile.yaml": ("localhost:5433", f"localhost:{port}"),
+    }
+
+    for rel, (old, new) in edits.items():
+        path = CWD / rel
+        text = path.read_text()
+        if old not in text:
+            raise ValueError(f"post_gen: expected {old!r} in {rel}; port not applied")
+        path.write_text(text.replace(old, new))
 
 
 def create_env():
@@ -152,6 +189,7 @@ def print_final_instructions():
 
 
 runners = [
+    assign_embedded_port,
     create_env,
     database_choice,
     handle_compose,

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -45,6 +45,9 @@ EMBEDDED_POSTGRES=true
 # Not under tmp/ — that is air's scratch directory, and a rebuild there would
 # delete the dev database.
 EMBEDDED_POSTGRES_DIR=./.data/postgres
+# Derived from the project name at generation time so two projects can run at
+# once. Startup refuses a port held by anything it cannot prove is its own,
+# rather than attaching to another project's database.
 EMBEDDED_POSTGRES_PORT=5433
 {% else -%}
 #----------------------------------------

--- a/{{ cookiecutter.project_slug }}/internal/embeddedpg/embeddedpg.go
+++ b/{{ cookiecutter.project_slug }}/internal/embeddedpg/embeddedpg.go
@@ -5,6 +5,7 @@ package embeddedpg
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -43,6 +44,9 @@ type Server struct {
 	// owned temp dirs cleaned up on Stop
 	ownedDataDir    string
 	ownedRuntimeDir string
+	// adopted marks a postmaster that outlived the process which launched
+	// it, so this Server has no library handle to stop it through.
+	adopted bool
 }
 
 func (o *Options) applyDefaults() error {
@@ -89,6 +93,70 @@ func stableBinDir(version embeddedpostgres.PostgresVersion) (string, error) {
 	return filepath.Join(home, ".embedded-postgres-go", string(version), "extracted"), nil
 }
 
+// isOwnPostmaster reports whether the process holding port is the postmaster
+// for dataDir. postmaster.pid records both facts — the data directory on line
+// 2 and the port on line 4 — so no connection is needed to tell this
+// instance's own leftover from a different checkout sharing the port.
+func isOwnPostmaster(dataDir string, port uint32) bool {
+	if dataDir == "" {
+		return false
+	}
+	lines, err := readPostmasterFile(dataDir)
+	if err != nil || len(lines) < 4 {
+		return false
+	}
+	pid, err := strconv.Atoi(lines[0])
+	if err != nil || !processAlive(pid) {
+		return false
+	}
+	recordedPort, err := strconv.Atoi(lines[3])
+	if err != nil || uint32(recordedPort) != port {
+		return false
+	}
+	return sameDir(lines[1], dataDir)
+}
+
+func readPostmasterFile(dataDir string) ([]string, error) {
+	b, err := os.ReadFile(filepath.Join(dataDir, "postmaster.pid"))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimRight(string(b), "\n"), "\n"), nil
+}
+
+// sameDir compares paths through symlinks, because macOS resolves the temp
+// dirs used for data directories via /private.
+func sameDir(a, b string) bool {
+	resolve := func(p string) string {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return filepath.Clean(p)
+		}
+		if real, err := filepath.EvalSymlinks(abs); err == nil {
+			return real
+		}
+		return abs
+	}
+	return resolve(a) == resolve(b)
+}
+
+func portConflict(port uint32, dataDir string) error {
+	if dataDir == "" {
+		return fmt.Errorf("embeddedpg: %w: %d", ErrPortInUse, port)
+	}
+	return fmt.Errorf(
+		"embeddedpg: %w: %d is held by a postmaster that is not the one for %s "+
+			"(another checkout, or a stale instance); stop it or set EMBEDDED_POSTGRES_PORT",
+		ErrPortInUse, port, dataDir,
+	)
+}
+
+// ErrPortInUse reports that the port is held by a postmaster this instance
+// cannot prove is its own. Adopting one blindly makes two checkouts share a
+// database, and the difference only surfaces later as errors against tables
+// that look correct on disk.
+var ErrPortInUse = errors.New("port already in use")
+
 // portInUse reports whether something already accepts connections on port.
 func portInUse(port uint32) bool {
 	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
@@ -104,21 +172,25 @@ func portInUse(port uint32) bool {
 // Stop. Each call uses its own RuntimePath so parallel instances do not
 // race on extraction.
 //
-// For persistent dev use (DataDir set): if the port is already occupied —
-// e.g. a previous run was killed before Stop() — Start returns a handle
-// pointing at the existing process without launching a new one; Stop on
-// such a handle is a no-op.
+// A persistent instance (DataDir set) whose port is already held by its own
+// postmaster is adopted rather than restarted — air SIGKILLs the app on
+// reload, so Postgres routinely outlives it. Any other occupant is fatal;
+// see ErrPortInUse.
 func Start(opts Options) (*Server, error) {
 	if err := opts.applyDefaults(); err != nil {
 		return nil, err
 	}
 
-	if opts.DataDir != "" && portInUse(opts.Port) {
-		dsn := fmt.Sprintf(
-			"postgres://%s:%s@localhost:%d/%s?sslmode=disable",
-			opts.User, opts.Password, opts.Port, opts.Database,
-		)
-		return &Server{DSN: dsn}, nil
+	dsn := fmt.Sprintf(
+		"postgres://%s:%s@localhost:%d/%s?sslmode=disable",
+		opts.User, opts.Password, opts.Port, opts.Database,
+	)
+
+	if portInUse(opts.Port) {
+		if !isOwnPostmaster(opts.DataDir, opts.Port) {
+			return nil, portConflict(opts.Port, opts.DataDir)
+		}
+		return &Server{DSN: dsn, dataDir: opts.DataDir, adopted: true}, nil
 	}
 
 	// Reclaim what earlier runs could not: Stop never runs under SIGKILL,
@@ -182,10 +254,6 @@ func Start(opts Options) (*Server, error) {
 		return nil, fmt.Errorf("embeddedpg: start: %w", err)
 	}
 
-	dsn := fmt.Sprintf(
-		"postgres://%s:%s@localhost:%d/%s?sslmode=disable",
-		opts.User, opts.Password, opts.Port, opts.Database,
-	)
 	return &Server{
 		DSN:             dsn,
 		pg:              pg,
@@ -202,6 +270,12 @@ func Start(opts Options) (*Server, error) {
 // is still alive. So Stop reads the postmaster PID before asking the
 // library to stop, and force-kills it afterward if it is still running.
 func (s *Server) Stop() error {
+	// An adopted postmaster was launched by someone else and may still be
+	// serving them; a caller that never started it does not get to end it.
+	// It survives as an orphan, which the next run in this data dir adopts.
+	if s.adopted {
+		return nil
+	}
 	if s.pg != nil {
 		pid, pidErr := readPostmasterPID(s.dataDir)
 

--- a/{{ cookiecutter.project_slug }}/internal/embeddedpg/start_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/embeddedpg/start_test.go
@@ -1,0 +1,168 @@
+package embeddedpg_test
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/embeddedpg"
+)
+
+// occupyPort holds a port for the duration of the test, standing in for a
+// postmaster that outlived the process which started it.
+func occupyPort(t *testing.T) uint32 {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { l.Close() }) //nolint:errcheck
+	return uint32(l.Addr().(*net.TCPAddr).Port)
+}
+
+// writePostmasterFile writes a postmaster.pid with the layout Postgres uses:
+// pid, data directory, start time, port, then socket details.
+func writePostmasterFile(t *testing.T, dir string, pid int, dataDir string, port uint32) {
+	t.Helper()
+	body := fmt.Sprintf("%d\n%s\n1753800000\n%d\n/tmp\nlocalhost\n5432001         1\nready\n",
+		pid, dataDir, port)
+	if err := os.WriteFile(filepath.Join(dir, "postmaster.pid"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// liveProcess returns the pid of a running process standing in for a
+// postmaster. It must be a direct child so the goroutine below can reap it:
+// an unreaped zombie still answers kill(pid, 0), which would hide whether
+// Stop worked. Spawning it via `sh -c ... &` would also make it inherit
+// SIG_IGN for SIGINT, so only the force-kill backstop could end it.
+func liveProcess(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go cmd.Wait()                            //nolint:errcheck
+	t.Cleanup(func() { cmd.Process.Kill() }) //nolint:errcheck
+	return cmd.Process.Pid
+}
+
+func newDataDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "postgres")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Air SIGKILLs the app on every reload, so Postgres routinely outlives the
+// process that started it. The next build must attach to it, not refuse.
+func TestStartAdoptsItsOwnPostmasterAcrossReload(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := newDataDir(t)
+	writePostmasterFile(t, dataDir, os.Getpid(), dataDir, port)
+
+	srv, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+
+	if err != nil {
+		t.Fatalf("own postmaster must be adopted, got: %v", err)
+	}
+	if !strings.Contains(srv.DSN, strconv.Itoa(int(port))) {
+		t.Errorf("DSN should point at the adopted port, got %s", srv.DSN)
+	}
+}
+
+// The bug this guards: two projects both defaulting to one port meant the
+// second adopted the first's cluster and ran its migrations into it.
+func TestStartRefusesAPostmasterForAnotherDataDir(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := newDataDir(t)
+	writePostmasterFile(t, dataDir, os.Getpid(), "/somewhere/else/postgres", port)
+
+	srv, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+
+	if srv != nil {
+		t.Fatalf("another checkout's database must never be adopted, got %+v", srv)
+	}
+	if !errors.Is(err, embeddedpg.ErrPortInUse) {
+		t.Fatalf("want ErrPortInUse, got %v", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(int(port))) {
+		t.Errorf("error should name the port, got: %v", err)
+	}
+}
+
+func TestStartRefusesAnOccupantWithNoPostmasterFile(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := filepath.Join(t.TempDir(), "postgres")
+
+	srv, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+
+	if srv != nil {
+		t.Fatalf("an unidentified occupant must not be adopted, got %+v", srv)
+	}
+	if !errors.Is(err, embeddedpg.ErrPortInUse) {
+		t.Fatalf("want ErrPortInUse, got %v", err)
+	}
+	if _, statErr := os.Stat(dataDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("a refused start must not create %s", dataDir)
+	}
+}
+
+func TestStartRefusesADeadPostmaster(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := newDataDir(t)
+	writePostmasterFile(t, dataDir, 0x7FFFFFFE, dataDir, port)
+
+	_, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+
+	if !errors.Is(err, embeddedpg.ErrPortInUse) {
+		t.Fatalf("a stale pid file must not authorise adoption, got %v", err)
+	}
+}
+
+// Our own instance recorded on a different port means the thing holding this
+// port is somebody else, however familiar the data dir looks.
+func TestStartRefusesWhenOurPostmasterRunsElsewhere(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := newDataDir(t)
+	writePostmasterFile(t, dataDir, os.Getpid(), dataDir, port+1)
+
+	_, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+
+	if !errors.Is(err, embeddedpg.ErrPortInUse) {
+		t.Fatalf("want ErrPortInUse, got %v", err)
+	}
+}
+
+// A failed startup calls Stop on its way out. An adopted postmaster belongs
+// to whoever launched it — very likely a dev server still using it — so Stop
+// must leave it alone rather than take the database down with it.
+func TestStopLeavesAnAdoptedPostmasterRunning(t *testing.T) {
+	port := occupyPort(t)
+	dataDir := newDataDir(t)
+	pid := liveProcess(t)
+	writePostmasterFile(t, dataDir, pid, dataDir, port)
+
+	srv, err := embeddedpg.Start(embeddedpg.Options{DataDir: dataDir, Port: port})
+	if err != nil {
+		t.Fatalf("adoption failed: %v", err)
+	}
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("Stop killed adopted postmaster pid %d: %v", pid, err)
+	}
+}


### PR DESCRIPTION
Fixes a bug shipped in v0.2.0. Found by running `task dev` in a freshly generated project:

```
INFO  starting embedded postgres dir=./.data/postgres port=5433
DEBUG waiting for database attempt=1 of=30 err=... FATAL: database "go-web-app" does not exist (SQLSTATE 3D000)
```

The migration wait is a red herring — it was never going to succeed.

## What actually happened

`Start()` adopted whatever was listening on the configured port whenever `DataDir` was set, with no check on what it had attached to:

```go
if opts.DataDir != "" && portInUse(opts.Port) {
    dsn := fmt.Sprintf("postgres://...@localhost:%d/%s?sslmode=disable", opts.Port, opts.Database)
    return &Server{DSN: dsn}, nil   // whatever that is
}
```

Every generated project also defaulted to port **5433**. On the machine where this surfaced, 5433 was held by an unrelated project's dev database, orphaned the previous day:

```
postgres -D .data/postgres -p 5433
```

So the new project attached to that cluster and asked for a database that only exists in its own. Hence `3D000`.

## The error is the good case

Two checkouts of the *same* project — a git worktree, a second clone — share a slug, so they share a port **and a database name**. Adoption succeeds, the name resolves, and `goose.Up` runs into the other checkout's database. Nothing reports anything. You get a schema you did not ask for in a database that looks correct on disk.

That is the failure mode this PR is really about.

## The fix

`Start` now reads `postmaster.pid` — line 2 is the data directory, line 4 the port — and adopts only when both match what was requested *and* the recorded pid is alive. No connection needed. Anything else returns `ErrPortInUse`, naming the port and the directory it expected:

```
embeddedpg: port already in use: 5433 is held by a postmaster that is not
the one for ./.data/postgres (another checkout, or a stale instance);
stop it or set EMBEDDED_POSTGRES_PORT
```

**Adoption has to stay.** air SIGKILLs the app on every reload, so Postgres routinely outlives the process that started it; refusing outright would break `task dev` on every save. The guard narrows adoption to the one case it was written for.

`Stop()` now leaves an adopted postmaster running. A failed boot calls `Stop` on its way out, and an adopted process belongs to whoever launched it — very likely a dev server still using it.

## Ports are now per-project

The fixed 5433 default is replaced by one derived from the slug at generation time, written into `.env.example`, `config.go` and the Taskfile's `DEV_DSN`:

```
go-web-app     16154        my-app     15927
case-one       16010        case-two   15749
```

`15432 + crc32(slug) % 1000`. One note on the band: this deliberately avoids the ephemeral range, despite that being the obvious place for "pick an unused port". The kernel allocates from there dynamically (Linux from 32768, macOS from 49152), so a port reserved there can already be in use by something else. 15432–16431 sits below both and stays greppable when you reach for `psql`.

The derived port makes collisions rare; the guard makes them loud. Both matter — a derived port is still just a default someone can override into a conflict.

## Verified

Reproduced the original failure against a real occupant on 5433, then confirmed the fix turns it into an immediate, actionable error instead of 30 retries into `3D000`.

- Fresh boot on the derived port: migrates and serves `/healthz` 200, Postgres on 16154.
- `kill -9` the app, then restart: adopts its own surviving postmaster and comes back healthy — the `task dev` path still works.
- Six new tests in `start_test.go` cover adopt-own, refuse-other-datadir, refuse-unidentified-occupant, refuse-dead-pid, refuse-our-postmaster-on-another-port, and Stop-leaves-adopted-alive. All use a fake `postmaster.pid` and a stand-in process, so the whole file runs in under a second with no Postgres download.
- Full generation matrix: six flag combinations, generate → tidy → sqlc → templ → build → vet → test → no-unrendered-Jinja. All pass.

Tag v0.2.1 once merged.
