### PR TITLE
Install the access-log schema on both halves, not just the middleware

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import textwrap
 import zlib
 from pathlib import Path
@@ -165,6 +166,24 @@ def prune_empty_dirs():
             target.rmdir()
 
 
+def format_go_sources():
+    """Format the rendered Go sources.
+
+    Struct field alignment and import order both depend on which conditional
+    blocks fired, so no template can be written that is correct for every
+    combination of options. Formatting after rendering is the only way to get
+    them right, and without it a fresh project fails its own `task audit`.
+    """
+    gofmt = shutil.which("gofmt")
+    if gofmt is None:
+        print("post_gen: gofmt not on PATH; generated sources left unformatted")
+        return
+
+    result = subprocess.run([gofmt, "-w", str(CWD)], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"post_gen: gofmt failed, sources left unformatted:\n{result.stderr}")
+
+
 def print_final_instructions():
     message = """
     ====================================================================================
@@ -198,6 +217,7 @@ runners = [
     handle_nats_package,
     handle_river_package,
     prune_empty_dirs,
+    format_go_sources,
     print_final_instructions,
 ]
 

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -118,6 +118,39 @@ restart per missing variable.
 
 Set `APP_ENV=production` in a deployment: it turns the development-friendly
 defaults into hard startup errors.
+
+## Logging
+
+`LOG_JSON=false` prints one coloured line per record for local work.
+`LOG_JSON=true` emits JSON using [OpenTelemetry][otel] field names — including
+for slog's own keys, which are **not** left at their defaults:
+
+| slog default | Emitted as |
+|---|---|
+| `time` | `timestamp` |
+| `level` | `severity_text` |
+| `msg` | `body` |
+| `error` | `error.message` |
+
+Point log queries and dashboards at those names. The choice lives in one place,
+`logging.AccessLogSchema`, and both the application logger and the access log
+read it — installing it on only one of them is what produces records that are
+half OTEL and half slog. Switching to Elastic Common Schema is a one-word
+change there, but it renames every field, so decide before building dashboards
+rather than after.
+
+Any record logged with a request context carries `trace_id`, so a line written
+deep in a service call ties back to the request that caused it.
+
+Access logs are [httplog][httplog]'s and take their level from the response
+status: 5xx error, 4xx warn, everything else info.
+Health checks{% if not cookiecutter.api_only %} and static assets{% endif %} are not logged at all, and a 404
+for a route that never matched is logged at info rather than warn, so bot
+probing does not turn the dashboard yellow. A handler returning 404 for a
+missing resource still warns.
+
+[otel]: https://opentelemetry.io/docs/specs/semconv/general/logs/
+[httplog]: https://github.com/go-chi/httplog
 {% if not cookiecutter.api_only %}
 ## HTTP surface
 

--- a/{{ cookiecutter.project_slug }}/internal/logging/grouping_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/grouping_test.go
@@ -1,0 +1,137 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"testing/slogtest"
+)
+
+func group(t *testing.T, entry map[string]any, name string) map[string]any {
+	t.Helper()
+	inner, ok := entry[name].(map[string]any)
+	if !ok {
+		t.Fatalf("group %q missing or not an object in %v", name, entry)
+	}
+	return inner
+}
+
+// trace_id is what ties a log line back to the request that caused it, so a
+// query for one must find every record. Adding it to the record would nest it
+// inside whatever group is open, putting some records out of reach.
+func TestSlogHandlerTraceIDStaysTopLevelUnderGroup(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(newTestHandler(&buf)).WithGroup("req")
+
+	logger.InfoContext(WithTraceID(context.Background(), "t-1"), "msg", slog.String("path", "/x"))
+	entry := decode(t, &buf)
+
+	if entry["trace_id"] != "t-1" {
+		t.Errorf("trace_id = %v, want t-1 at the top level: %v", entry["trace_id"], entry)
+	}
+	if got := group(t, entry, "req")["path"]; got != "/x" {
+		t.Errorf("req.path = %v, want /x — record attrs must still be grouped", got)
+	}
+	if _, nested := group(t, entry, "req")["trace_id"]; nested {
+		t.Errorf("trace_id also nested inside the group: %v", entry)
+	}
+}
+
+func TestSlogHandlerGroupingCombinations(t *testing.T) {
+	tests := []struct {
+		name   string
+		build  func(*slog.Logger) *slog.Logger
+		assert func(*testing.T, map[string]any)
+	}{
+		{
+			name:  "attrs before a group stay top level",
+			build: func(l *slog.Logger) *slog.Logger { return l.With(slog.String("svc", "api")).WithGroup("g") },
+			assert: func(t *testing.T, e map[string]any) {
+				if e["svc"] != "api" {
+					t.Errorf("svc = %v, want api at top level", e["svc"])
+				}
+				if got := group(t, e, "g")["path"]; got != "/x" {
+					t.Errorf("g.path = %v, want /x", got)
+				}
+			},
+		},
+		{
+			name:  "attrs after a group are grouped",
+			build: func(l *slog.Logger) *slog.Logger { return l.WithGroup("g").With(slog.String("svc", "api")) },
+			assert: func(t *testing.T, e map[string]any) {
+				if got := group(t, e, "g")["svc"]; got != "api" {
+					t.Errorf("g.svc = %v, want api", got)
+				}
+			},
+		},
+		{
+			name:  "nested groups",
+			build: func(l *slog.Logger) *slog.Logger { return l.WithGroup("a").WithGroup("b") },
+			assert: func(t *testing.T, e map[string]any) {
+				if got := group(t, group(t, e, "a"), "b")["path"]; got != "/x" {
+					t.Errorf("a.b.path = %v, want /x", got)
+				}
+			},
+		},
+		{
+			name:  "empty group name is a no-op",
+			build: func(l *slog.Logger) *slog.Logger { return l.WithGroup("") },
+			assert: func(t *testing.T, e map[string]any) {
+				if e["path"] != "/x" {
+					t.Errorf("path = %v, want /x at top level", e["path"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := tt.build(slog.New(newTestHandler(&buf)))
+
+			logger.InfoContext(WithTraceID(context.Background(), "t-1"), "msg", slog.String("path", "/x"))
+			entry := decode(t, &buf)
+
+			if entry["trace_id"] != "t-1" {
+				t.Errorf("trace_id = %v, want t-1 at the top level: %v", entry["trace_id"], entry)
+			}
+			tt.assert(t, entry)
+		})
+	}
+}
+
+// Branching a logger must not let one child's attrs leak into its sibling.
+func TestSlogHandlerGroupedBranchesAreIndependent(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.New(newTestHandler(&buf)).WithGroup("g")
+
+	base.With(slog.String("branch", "left")).InfoContext(context.Background(), "msg")
+	left := decode(t, &buf)
+
+	buf.Reset()
+	base.With(slog.String("branch", "right")).InfoContext(context.Background(), "msg")
+	right := decode(t, &buf)
+
+	if got := group(t, left, "g")["branch"]; got != "left" {
+		t.Errorf("left branch = %v, want left", got)
+	}
+	if got := group(t, right, "g")["branch"]; got != "right" {
+		t.Errorf("right branch = %v, want right", got)
+	}
+}
+
+// The standard library's own conformance suite for slog.Handler
+// implementations. It is what catches the contract details a hand-written
+// handler is easy to get wrong: empty groups, inline groups, resolving
+// LogValuers.
+func TestSlogHandlerConformsToSlogContract(t *testing.T) {
+	var buf bytes.Buffer
+	slogtest.Run(t,
+		func(*testing.T) slog.Handler {
+			buf.Reset()
+			return &SlogHandler{inner: slog.NewJSONHandler(&buf, nil)}
+		},
+		func(t *testing.T) map[string]any { return decode(t, &buf) },
+	)
+}

--- a/{{ cookiecutter.project_slug }}/internal/logging/httplog_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/httplog_test.go
@@ -1,0 +1,148 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/httplog/v3"
+)
+
+func jsonLogger(t *testing.T, buf *bytes.Buffer) *slog.Logger {
+	t.Helper()
+	cfg := &config.Conf{}
+	cfg.AppConf.LogJson = true
+	cfg.AppConf.LogLevel = slog.LevelDebug
+	return SetupLogger(cfg, WithOutput(buf))
+}
+
+// The schema has to be installed on the handler as well as on the middleware.
+// With only the middleware half wired up the attributes are OTEL-named but
+// slog's own keys are not, which is not a format any collector understands.
+func TestSetupLoggerJSONUsesSchemaFieldNames(t *testing.T) {
+	var buf bytes.Buffer
+	jsonLogger(t, &buf).Info("hello")
+	entry := decode(t, &buf)
+
+	for _, key := range []string{"timestamp", "severity_text", "body"} {
+		if _, ok := entry[key]; !ok {
+			t.Errorf("missing OTEL key %q in %v", key, entry)
+		}
+	}
+	for _, key := range []string{"time", "level", "msg"} {
+		if _, ok := entry[key]; ok {
+			t.Errorf("slog key %q survived, want it renamed: %v", key, entry)
+		}
+	}
+}
+
+// httplog reports a client disconnect as slog.Any("error", ...), which the
+// schema is what rewrites to error.message.
+func TestSetupLoggerJSONRenamesErrorKey(t *testing.T) {
+	var buf bytes.Buffer
+	jsonLogger(t, &buf).Error("boom", slog.Any(httplog.ErrorKey, errors.New("aborted")))
+	entry := decode(t, &buf)
+
+	if _, ok := entry["error.message"]; !ok {
+		t.Errorf("error not renamed to error.message: %v", entry)
+	}
+}
+
+// httplog's own ReplaceAttr formats at RFC3339, which rounds to the second and
+// makes same-second records unorderable.
+func TestOTELReplaceAttrKeepsSubSecondPrecision(t *testing.T) {
+	ts := time.Date(2026, 8, 8, 10, 30, 0, 123456789, time.UTC)
+
+	got := otelReplaceAttr(nil, slog.Time(slog.TimeKey, ts))
+
+	if got.Key != "timestamp" {
+		t.Errorf("key = %q, want timestamp", got.Key)
+	}
+	if want := ts.Format(time.RFC3339Nano); got.Value.String() != want {
+		t.Errorf("value = %q, want %q", got.Value.String(), want)
+	}
+}
+
+func routeCtx(pattern string) context.Context {
+	rctx := chi.NewRouteContext()
+	if pattern != "" {
+		rctx.RoutePatterns = []string{pattern}
+	}
+	return context.WithValue(context.Background(), chi.RouteCtxKey, rctx)
+}
+
+// A 404 from an unmatched route is bot noise; a 404 from a route that matched
+// is a genuinely missing resource. Only the first is demoted, and a request
+// that never went through the mux at all must not be touched.
+func TestSlogHandlerDemotesUnmatchedRouteWarnings(t *testing.T) {
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		level slog.Level
+		want  string
+	}{
+		{"unmatched route", routeCtx(""), slog.LevelWarn, "INFO"},
+		{"matched route", routeCtx("/widgets/{id}"), slog.LevelWarn, "WARN"},
+		{"no route context", context.Background(), slog.LevelWarn, "WARN"},
+		{"errors are never demoted", routeCtx(""), slog.LevelError, "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(newTestHandler(&buf))
+
+			logger.Log(tt.ctx, tt.level, "msg")
+
+			if got := decode(t, &buf)["level"]; got != tt.want {
+				t.Errorf("level = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The whole seam end to end: chi decides whether a route matched, httplog
+// decides the level from the status, and the handler demotes the noise.
+func TestAccessLogLevelThroughChi(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"unmatched route is routine", "/wp-admin", "INFO"},
+		{"matched route returning 404 still warns", "/widgets/9", "WARN"},
+		{"success is routine", "/widgets", "INFO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := jsonLogger(t, &buf)
+
+			r := chi.NewMux()
+			r.Use(httplog.RequestLogger(logger, &httplog.Options{
+				Level:  slog.LevelInfo,
+				Schema: AccessLogSchema,
+			}))
+			r.Get("/widgets", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+			r.Get("/widgets/{id}", func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "no such widget", http.StatusNotFound)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			r.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got := decode(t, &buf)["severity_text"]; got != tt.want {
+				t.Errorf("severity_text = %v, want %v (%q)", got, tt.want, buf.String())
+			}
+		})
+	}
+}

--- a/{{ cookiecutter.project_slug }}/internal/logging/logging.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/logging.go
@@ -1,7 +1,9 @@
-// Package logging builds the application slog.Logger from config.
+// Package logging builds the application slog.Logger from config and owns the
+// field-name schema shared with the access log.
 //
-// Access logging is not here: go-chi/httplog owns that, wired up in
-// internal/server.
+// Access logging itself is go-chi/httplog's, wired up in internal/server. The
+// schema has to be installed on both halves — the handler here, the middleware
+// there — or records come out with OTEL attributes under slog's own key names.
 package logging
 
 import (
@@ -9,12 +11,31 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
 
 	"github.com/SladkyCitron/slogcolor"
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/httplog/v3"
 )
+
+// AccessLogSchema is the field-name schema for both the application logger and
+// the access log. internal/server passes it to httplog; keep it the one source
+// of truth so the two halves cannot drift apart.
+var AccessLogSchema = httplog.SchemaOTEL
+
+// otelReplaceAttr renames slog's built-in keys to AccessLogSchema. The
+// timestamp is handled here rather than by the schema because httplog formats
+// it at RFC3339's one-second resolution, which leaves same-second records
+// unorderable.
+func otelReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 && a.Key == slog.TimeKey {
+		return slog.String(AccessLogSchema.Timestamp, a.Value.Time().Format(time.RFC3339Nano))
+	}
+	return AccessLogSchema.ReplaceAttr(groups, a)
+}
 
 // Option customises logger construction.
 type Option func(*options)
@@ -52,11 +73,20 @@ func (h *SlogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *SlogHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn && unmatchedRoute(ctx) {
+		r.Level = slog.LevelInfo
+		if !h.inner.Enabled(ctx, r.Level) {
+			return nil
+		}
+	}
 	traceID := TraceID(ctx)
 	if traceID == "" {
 		traceID = middleware.GetReqID(ctx)
 	}
 	if traceID != "" {
+		// Cloned because AddAttrs can append into a backing array the caller
+		// still shares, which would corrupt a sibling handler's copy.
+		r = r.Clone()
 		r.AddAttrs(slog.String("trace_id", traceID))
 	}
 	return h.inner.Handle(ctx, r)
@@ -70,6 +100,15 @@ func (h *SlogHandler) WithGroup(name string) slog.Handler {
 	return &SlogHandler{inner: h.inner.WithGroup(name)}
 }
 
+// unmatchedRoute reports whether ctx belongs to a request that reached the mux
+// and matched nothing, which httplog would otherwise log at warn. A handler
+// answering 404 for a missing resource is a real warning and keeps its level;
+// so does anything with no route context at all, such as a background job.
+func unmatchedRoute(ctx context.Context) bool {
+	rctx := chi.RouteContext(ctx)
+	return rctx != nil && rctx.RoutePattern() == ""
+}
+
 // SetupLogger returns the application logger: JSON for deployments, coloured
 // single lines for local dev.
 func SetupLogger(cfg *config.Conf, opts ...Option) *slog.Logger {
@@ -81,7 +120,8 @@ func SetupLogger(cfg *config.Conf, opts ...Option) *slog.Logger {
 	var handler slog.Handler
 	if cfg.AppConf.LogJson {
 		handler = slog.NewJSONHandler(o.out, &slog.HandlerOptions{
-			Level: cfg.AppConf.LogLevel,
+			Level:       cfg.AppConf.LogLevel,
+			ReplaceAttr: otelReplaceAttr,
 		})
 	} else {
 		// Built from DefaultOptions rather than a bare literal: the zero value

--- a/{{ cookiecutter.project_slug }}/internal/logging/logging.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/logging.go
@@ -66,6 +66,23 @@ func TraceID(ctx context.Context) string {
 // request that caused it.
 type SlogHandler struct {
 	inner slog.Handler
+	// ungrouped is inner as it stood before the first WithGroup, and ops
+	// replays everything applied since. Both stay nil until a group is opened,
+	// so the usual case never pays for them.
+	ungrouped slog.Handler
+	ops       []handlerOp
+}
+
+// handlerOp replays one WithAttrs or WithGroup call onto a different handler.
+type handlerOp func(slog.Handler) slog.Handler
+
+func cloneOps(ops []handlerOp) []handlerOp {
+	if len(ops) == 0 {
+		return nil
+	}
+	out := make([]handlerOp, len(ops), len(ops)+1)
+	copy(out, ops)
+	return out
 }
 
 func (h *SlogHandler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -83,21 +100,56 @@ func (h *SlogHandler) Handle(ctx context.Context, r slog.Record) error {
 	if traceID == "" {
 		traceID = middleware.GetReqID(ctx)
 	}
-	if traceID != "" {
+	if traceID == "" {
+		return h.inner.Handle(ctx, r)
+	}
+
+	attr := slog.String("trace_id", traceID)
+	if h.ungrouped == nil {
 		// Cloned because AddAttrs can append into a backing array the caller
 		// still shares, which would corrupt a sibling handler's copy.
 		r = r.Clone()
-		r.AddAttrs(slog.String("trace_id", traceID))
+		r.AddAttrs(attr)
+		return h.inner.Handle(ctx, r)
 	}
-	return h.inner.Handle(ctx, r)
+
+	// With a group open the attr cannot go on the record: it would land inside
+	// the group, and a search for a trace id would miss every line logged
+	// through a grouped logger. Apply it ahead of the first group instead.
+	target := h.ungrouped.WithAttrs([]slog.Attr{attr})
+	for _, op := range h.ops {
+		target = op(target)
+	}
+	return target.Handle(ctx, r)
 }
 
 func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &SlogHandler{inner: h.inner.WithAttrs(attrs)}
+	if len(attrs) == 0 {
+		return h
+	}
+	n := &SlogHandler{inner: h.inner.WithAttrs(attrs), ungrouped: h.ungrouped}
+	if n.ungrouped != nil {
+		n.ops = append(cloneOps(h.ops), func(x slog.Handler) slog.Handler {
+			return x.WithAttrs(attrs)
+		})
+	}
+	return n
 }
 
 func (h *SlogHandler) WithGroup(name string) slog.Handler {
-	return &SlogHandler{inner: h.inner.WithGroup(name)}
+	if name == "" {
+		return h
+	}
+	n := &SlogHandler{inner: h.inner.WithGroup(name), ungrouped: h.ungrouped, ops: cloneOps(h.ops)}
+	if n.ungrouped == nil {
+		// Everything so far belongs to the handler this group opens on, so
+		// there is nothing to replay yet.
+		n.ungrouped, n.ops = h.inner, nil
+	}
+	n.ops = append(n.ops, func(x slog.Handler) slog.Handler {
+		return x.WithGroup(name)
+	})
+	return n
 }
 
 // unmatchedRoute reports whether ctx belongs to a request that reached the mux

--- a/{{ cookiecutter.project_slug }}/internal/logging/logging_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/logging_test.go
@@ -46,17 +46,6 @@ func TestSlogHandler_WithAttrs(t *testing.T) {
 	}
 }
 
-func TestSlogHandler_WithGroup(t *testing.T) {
-	var buf bytes.Buffer
-	handler := newTestHandler(&buf)
-
-	newHandler := handler.WithGroup("test-group")
-
-	if _, ok := newHandler.(*SlogHandler); !ok {
-		t.Fatal("WithGroup should return a *SlogHandler, or the trace_id wrapper is lost")
-	}
-}
-
 func TestSlogHandler_HandleAddsTraceID(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(newTestHandler(&buf))

--- a/{{ cookiecutter.project_slug }}/internal/logging/logging_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/logging/logging_test.go
@@ -72,9 +72,9 @@ func TestSlogHandler_HandleAddsTraceID(t *testing.T) {
 // across a service boundary is not silently replaced by a per-request one.
 func TestSlogHandler_HandleFallsBackToRequestID(t *testing.T) {
 	tests := []struct {
-		name  string
-		ctx   func() context.Context
-		want  any
+		name string
+		ctx  func() context.Context
+		want any
 	}{
 		{
 			name: "request id only",
@@ -124,8 +124,8 @@ func TestSetupLoggerJSONHonoursLevel(t *testing.T) {
 
 	logger.WarnContext(WithTraceID(context.Background(), "t-2"), "kept")
 	entry := decode(t, &buf)
-	if entry["msg"] != "kept" {
-		t.Errorf("msg = %v, want kept", entry["msg"])
+	if entry["body"] != "kept" {
+		t.Errorf("body = %v, want kept — SetupLogger must install the schema", entry["body"])
 	}
 	if entry["trace_id"] != "t-2" {
 		t.Errorf("trace_id = %v, want t-2 — SetupLogger must wrap with SlogHandler", entry["trace_id"])

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -1,11 +1,13 @@
 package server
 
 import (
-	"log/slog"
-	"net/http"
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}
 	"strings"
 {% endif -%}
+	"log/slog"
+	"net/http"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/logging"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/go-chi/chi/v5"
@@ -35,13 +37,16 @@ func (app *App) ApiKeyAuth(api huma.API) func(ctx huma.Context, next func(huma.C
 // memory.
 func (app *App) httplogOptions() *httplog.Options {
 	o := &httplog.Options{
+		// A floor, not the level records are written at: httplog picks that from
+		// the status (5xx error, 4xx warn, OPTIONS debug). Info drops preflights.
 		Level:         slog.LevelInfo,
-		Schema:        httplog.SchemaOTEL.Concise(!app.Conf.AppConf.LogJson),
+		Schema:        logging.AccessLogSchema.Concise(!app.Conf.AppConf.LogJson),
 		RecoverPanics: true,
 		Skip:          app.skipRequestLog,
 	}
-	// Concise blanks the values but keeps the header keys, so headers are only
-	// worth collecting when the full schema is in play.
+	// Concise blanks most schema field names but keeps the header keys, so
+	// collecting headers in dev would print a lone header group beside an
+	// otherwise bare summary line.
 	if app.Conf.AppConf.LogJson {
 		if app.Conf.AppConf.LogRequestHeaders {
 			o.LogRequestHeaders = []string{"Origin"}


### PR DESCRIPTION
Three independent fixes found while reading the logging setup, plus one found while verifying them.

## The access log's schema was only half installed

`httplog.Schema` maps semantic log fields onto a naming convention, and it has to be installed in **two** places — on the middleware and on the slog handler. The template only ever did the first:

```go
// internal/server — done
httplog.RequestLogger(app.Log, &httplog.Options{Schema: httplog.SchemaOTEL.Concise(...)})

// internal/logging — missing
slog.NewJSONHandler(o.out, &slog.HandlerOptions{
    Level: cfg.AppConf.LogLevel,   // no ReplaceAttr
})
```

So production records came out half OTEL and half slog:

```json
{"time":"...","level":"INFO","msg":"GET /widgets => HTTP 200",
 "http.request.method":"GET","url.path":"/widgets","http.response.status_code":200}
```

The request attributes are semconv-compliant; `time`/`level`/`msg` should have been `timestamp`/`severity_text`/`body`. A collector configured for OTEL reads the request fields and none of the core ones — and nothing errors, nothing is empty, the logs look fine.

The same gap affected error reporting. httplog reports a client disconnect as `slog.Any("error", ...)`, and `ReplaceAttr` is what rewrites that key to `error.message`.

`AccessLogSchema` now holds the choice once and both halves consume it. The timestamp is handled locally rather than by the schema, which formats at `RFC3339` — one-second resolution, leaving same-second records unorderable.

Note this renames `time`/`level`/`msg` in deployed JSON output. The field names are now documented in the generated project's README.

## trace_id was unreachable under an open group

The handler added `trace_id` to the record, so once a group was open it nested inside that group:

```json
{"g": {"path": "/x", "trace_id": "t-1"}}
```

`trace_id` is the field that ties a line back to the request that caused it, so a search for one silently missed every record logged through a grouped logger. That is the worst shape for a debugging aid — it looks like the request simply never logged.

An attr cannot be added to a record above an open group, so the handler now remembers itself as it stood before the first `WithGroup` along with the calls applied since, applies `trace_id` to that earlier handler, and replays the rest. Both fields stay nil until a group is opened, so the ungrouped path — which is every path this template currently takes, including the access log — is unchanged and pays nothing.

Records are also cloned before `trace_id` is appended. `AddAttrs` can append into a backing array the caller still shares: harmless with one inner handler, silently corrupting with two.

This adds the standard library's `slogtest` conformance suite, which covers the handler-contract details that are easy to get wrong by hand and that none of the existing tests reached.

## Unmatched-route 404s no longer log at warn

httplog derives its level from the status, so every bot probing `/wp-admin` produced a warning. But a 404 has two very different causes, and chi already distinguishes them: when nothing matched, `RoutePattern()` is empty.

```
/wp-admin       no route matched      -> info   (noise)
/widgets/{id}   handler returned 404  -> warn   (a real resource is missing)
```

The demotion requires a non-nil route context, so a background job's warning is never caught by an absent pattern looking the same as an unmatched one.

## Generated projects failed their own `task audit`

Unrelated, found while verifying the above: a default project rendered **eleven** gofmt-dirty files.

Most of it is not fixable in the template. Struct field alignment and import order depend on which conditional blocks fired — gofmt pads fields to the widest name in the block, so `Conf` needs four spaces when `PgxPool` renders and one when it doesn't. A static template can only encode one variant.

Better whitespace control was tried and doesn't work. Rewriting tags as `{%- ... %}` strips the blank lines separating import groups, so gofmt merges local imports into the stdlib group. Enabling `trim_blocks`/`lstrip_blocks` globally is the semantically right switch for Go, but `go.mod` and `assets/sqlc.yaml` are written against the current behaviour and render as syntax errors under it.

Running `gofmt` after rendering handles every case and can't regress when someone adds a conditional field later.
