### PR TITLE
Tidy the module before running the generators that depend on it

### DIFF
--- a/{{ cookiecutter.project_slug }}/Taskfile.yaml
+++ b/{{ cookiecutter.project_slug }}/Taskfile.yaml
@@ -26,6 +26,10 @@ vars:
   init:
     desc: Generate code and tidy modules. Run this once after generating the project.
     cmds:
+      # tidy first: `go tool templ` resolves the generator through the module
+      # graph, and the template ships no go.sum. The trailing tidy then picks up
+      # what only generated code imports.
+      - task: tidy
 {% endraw %}{% if not cookiecutter.api_only %}      - task: templ
 {% endif %}{% if cookiecutter.use_tailwind %}      - task: css
 {% endif %}{% raw %}      - task: sqlc


### PR DESCRIPTION
A freshly generated project could not complete `task init`, the command the
post-generation instructions tell you to run first:

```
task: [templ] go tool templ generate
missing go.sum entry for module providing package github.com/a-h/templ/cmd/templ; to add:
        go mod download github.com/a-h/templ
```

`init` ran templ, css and sqlc before `go mod tidy`. The template ships `go.mod`
with direct requires only and no `go.sum`, leaving the indirect set for tidy to
resolve — but Go 1.24's `tool` directive makes `go tool templ` a module-aware
invocation. It resolves `github.com/a-h/templ/cmd/templ` through the module
graph and wants verified checksums, which do not exist until tidy has written
them. Every project with a UI hit this.

`tidy` now runs at both ends of `init`. The leading one is there to write
`go.sum`. The trailing one is not redundant, and the comment in the Taskfile
says so: after the first pass templ is demoted to `// indirect`, because at that
point nothing but the `tool` directive refers to it and every real import lives
in the `*_templ.go` files that have not been generated yet. The second pass
promotes it back and picks up whatever else the generated code brought in.

Tidying before generation is safe because tidy resolves imports rather than
typechecking — a handler calling a templ component that does not exist yet is a
compile error, not a tidy error. It does rely on every package directory holding
at least one hand-written `.go` file, which `internal/ui/templates` (`views.go`)
and `internal/store` (`pool.go`, `migrate.go`) both do.

Docker and CI were never affected. Both build from a checkout where `go.sum` is
already committed, so the ordering only ever mattered on first init.

Existing generated projects do not need regenerating — `go mod tidy && task init`
unblocks them.
