### PR TITLE
Harden generated app security defaults

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def database_choice():
     Litestream and keeps the shell entrypoint that wraps the process.
     """
     if DB_CHOICE == "postgres":
-        remove("database", "litestream.yml", "entrypoint")
+        remove("database", "litestream.yml", "entrypoint", "internal/store/sqlite_test.go")
     elif DB_CHOICE == "sqlite":
         remove(
             "internal/embeddedpg",

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -13,7 +13,10 @@ SERVER_PORT=9898
 SERVER_TIMEOUT_READ=5s
 SERVER_TIMEOUT_WRITE=10s
 SERVER_TIMEOUT_IDLE=15s
-X_API_KEY=changeme
+# Required for any endpoint protected with ApiKeyAuth. Generate a unique
+# secret for each deployment; leaving this empty makes protected endpoints
+# reject every request.
+X_API_KEY=
 
 #----------------------------------------
 # Logging

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -65,7 +65,7 @@ type dbConf struct {
 {% endif -%}
 
 type serverConf struct {
-	XApiKey      string        `env:"X_API_KEY,default=changeme"`
+	XApiKey      string        `env:"X_API_KEY,default="`
 	Port         int           `env:"SERVER_PORT,default=9898"`
 	TimeoutRead  time.Duration `env:"SERVER_TIMEOUT_READ,default=5s"`
 	TimeoutWrite time.Duration `env:"SERVER_TIMEOUT_WRITE,default=10s"`
@@ -180,8 +180,8 @@ func Load() (*Conf, error) {
 {% endif -%}
 
 	if c.IsProduction() {
-		if c.Server.XApiKey == "changeme" {
-			problems = append(problems, "X_API_KEY must be changed from its default in production")
+		if c.Server.XApiKey == "" {
+			problems = append(problems, "X_API_KEY must be set in production")
 		}
 {% if cookiecutter.database_choice == 'postgres' -%}
 		if c.Db.Embedded {

--- a/{{ cookiecutter.project_slug }}/internal/config/config_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config_test.go
@@ -29,6 +29,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.IsProduction() {
 		t.Error("IsProduction() = true, want false: APP_ENV defaults to development")
 	}
+	if cfg.Server.XApiKey != "" {
+		t.Errorf("XApiKey = %q, want empty by default", cfg.Server.XApiKey)
+	}
 }
 
 // One pass should be enough to fix a misconfigured deployment, rather than one
@@ -37,7 +40,7 @@ func TestLoadReportsEveryProblemAtOnce(t *testing.T) {
 	setMinimalEnv(t)
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("SERVER_PORT", "70000")
-	// X_API_KEY is left at its default, which production rejects.
+	// X_API_KEY is left empty, which production rejects.
 
 	_, err := config.Load()
 	if err == nil {

--- a/{{ cookiecutter.project_slug }}/internal/jobs/client.go
+++ b/{{ cookiecutter.project_slug }}/internal/jobs/client.go
@@ -16,9 +16,7 @@ import (
 	"strings"
 
 	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
-{% if cookiecutter.database_choice == 'postgres' -%}
 	"{{ cookiecutter.go_module_path.strip() }}/internal/store"
-{% endif -%}
 
 {% if cookiecutter.database_choice == 'postgres' -%}
 	"github.com/jackc/pgx/v5"
@@ -91,7 +89,7 @@ func NewClient(
 	cfg *config.Conf,
 	log *slog.Logger,
 ) (*Client, error) {
-	db, err := sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)")
+	db, err := sql.Open("sqlite", store.DSN(dbPath))
 	if err != nil {
 		return nil, err
 	}

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -18,7 +18,10 @@ import (
 // config rather than the package-level loader so a test can supply its own.
 func (app *App) ApiKeyAuth(api huma.API) func(ctx huma.Context, next func(huma.Context)) {
 	return func(ctx huma.Context, next func(huma.Context)) {
-		if ctx.Header("X-API-Key") != app.Conf.Server.XApiKey {
+		// Fail closed when the operator has not configured a key. Comparing an
+		// empty header with an empty configured value would otherwise authorize
+		// every request that omitted X-API-Key.
+		if app.Conf.Server.XApiKey == "" || ctx.Header("X-API-Key") != app.Conf.Server.XApiKey {
 			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
 			return
 		}

--- a/{{ cookiecutter.project_slug }}/internal/server/routes.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes.go
@@ -31,7 +31,12 @@ import (
 func (app *App) Routes() http.Handler {
 	router := chi.NewMux()
 	router.Use(middleware.RequestID)
-	router.Use(middleware.RealIP)
+	// The template cannot know which reverse proxies a generated deployment
+	// trusts. Never infer a client IP from forwarded headers by default: those
+	// headers are client-controlled when the app is directly reachable. A
+	// deployment behind a proxy must replace this with a specifically trusted
+	// ClientIPFromHeader or ClientIPFromXFF configuration.
+	router.Use(middleware.ClientIPFromRemoteAddr)
 	// Recoverer sits outside the access log purely as a backstop for httplog
 	// itself: httplog recovers handler panics first and logs them with the
 	// request and a stack trace, which Recoverer alone cannot do.

--- a/{{ cookiecutter.project_slug }}/internal/store/migrate.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/migrate.go
@@ -97,7 +97,7 @@ func prepareMigrationDB(ctx context.Context, dsn string, logger *slog.Logger) (*
 	}
 
 {% endif -%}
-	db, err := sql.Open("{% if cookiecutter.database_choice == 'postgres' %}pgx{% else %}sqlite{% endif %}", dsn)
+	db, err := sql.Open("{% if cookiecutter.database_choice == 'postgres' %}pgx{% else %}sqlite{% endif %}", {% if cookiecutter.database_choice == 'postgres' %}dsn{% else %}DSN(dsn){% endif %})
 	if err != nil {
 		return nil, fmt.Errorf("store: open database for migrations: %w", err)
 	}

--- a/{{ cookiecutter.project_slug }}/internal/store/pool.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/pool.go
@@ -48,16 +48,29 @@ func NewDatabasePool(ctx context.Context, cfg *config.Conf) (*pgxpool.Pool, erro
 	return pgxpool.NewWithConfig(ctx, c)
 }
 {% else -%}
+// DSN turns a database file path into a SQLite connection string with the
+// pragmas required by the application's single-writer and Litestream model.
+// busy_timeout waits for the current writer instead of returning SQLITE_BUSY,
+// WAL permits readers during writes and is required for Litestream, and
+// foreign_keys makes SQLite enforce the same relational constraints callers
+// expect from the schema.
+func DSN(path string) string {
+	return path + "?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+}
+
 func NewDatabasePool(ctx context.Context, cfg *config.Conf) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", cfg.Db.DbName)
+	db, err := sql.Open("sqlite", DSN(cfg.Db.DbName))
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	if err = db.PingContext(ctx); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 	return db, nil

--- a/{{ cookiecutter.project_slug }}/internal/store/sqlite_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/sqlite_test.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
+)
+
+func TestSQLitePoolUsesSafeDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.db")
+	t.Setenv("DATABASE_URL", path)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	db, err := NewDatabasePool(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open database pool: %v", err)
+	}
+	defer db.Close()
+
+	if got := db.Stats().MaxOpenConnections; got != 1 {
+		t.Errorf("max open connections = %d, want 1", got)
+	}
+
+	var busyTimeout int
+	if err := db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 10000 {
+		t.Errorf("busy_timeout = %d, want 10000", busyTimeout)
+	}
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Errorf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var foreignKeys int
+	if err := db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+		t.Fatalf("read foreign_keys: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Errorf("foreign_keys = %d, want 1", foreignKeys)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("database file was not created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- stop trusting spoofable forwarded client IP headers by default
- apply safe SQLite WAL, busy-timeout, foreign-key, and single-writer defaults across app, migrations, and River
- remove the hardcoded API key and fail closed when no key is configured

## Issue coverage
- Related to #14: this fixes the SQLite connection pragmas, lock contention, WAL startup ordering, and migration connection settings. The remaining shared-`*sql.DB` / transactional enqueue redesign stays open and is not closed by this PR.

## Validation
- `git diff --check`
- hook Python syntax check
- generated-project matrix attempted but blocked by unavailable PyPI network access