### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def database_choice():
     Litestream and keeps the shell entrypoint that wraps the process.
     """
     if DB_CHOICE == "postgres":
-        remove("database", "litestream.yml", "entrypoint")
+        remove("database", "litestream.yml", "entrypoint", "internal/store/sqlite_test.go")
     elif DB_CHOICE == "sqlite":
         remove(
             "internal/embeddedpg",

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -13,7 +13,10 @@ SERVER_PORT=9898
 SERVER_TIMEOUT_READ=5s
 SERVER_TIMEOUT_WRITE=10s
 SERVER_TIMEOUT_IDLE=15s
-X_API_KEY=changeme
+# Required for any endpoint protected with ApiKeyAuth. Generate a unique
+# secret for each deployment; leaving this empty makes protected endpoints
+# reject every request.
+X_API_KEY=
 
 #----------------------------------------
 # Logging

--- a/{{ cookiecutter.project_slug }}/.golangci.yml
+++ b/{{ cookiecutter.project_slug }}/.golangci.yml
@@ -1,8 +1,9 @@
+version: "2"
+
 linters:
   enable:
     - sloglint
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -155,7 +155,7 @@ deep in a service call ties back to the request that caused it.
 
 Access logs are [httplog][httplog]'s and take their level from the response
 status: 5xx error, 4xx warn, everything else info.
-Health checks{% if not cookiecutter.api_only %} and static assets{% endif %} are not logged at all, and a 404
+Health checks, metrics{% if not cookiecutter.api_only %} and static assets{% endif %} are not logged at all, and a 404
 for a route that never matched is logged at info rather than warn, so bot
 probing does not turn the dashboard yellow. A handler returning 404 for a
 missing resource still warns.
@@ -168,6 +168,7 @@ missing resource still warns.
 | Path | What |
 |---|---|
 | `/healthz`, `/version` | Monitoring, also in the OpenAPI spec |
+| `/metrics` | Prometheus runtime, process, and HTTP metrics |
 | `/docs`, `/openapi.json` | API reference |
 | `/app` | The rendered UI |
 | `/app/welcome` | First-run tour of what was scaffolded — delete when it has served its purpose |
@@ -186,6 +187,7 @@ Pages are [templ](https://templ.guide) templates updated in place by
 | Path | What |
 |---|---|
 | `/healthz`, `/version` | Monitoring |
+| `/metrics` | Prometheus runtime, process, and HTTP metrics |
 | `/docs`, `/openapi.json` | API reference |
 {% endif %}
 ## Container

--- a/{{ cookiecutter.project_slug }}/go.mod
+++ b/{{ cookiecutter.project_slug }}/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/SladkyCitron/slogcolor v1.9.0
 	github.com/alecthomas/kong v1.16.0
 	github.com/danielgtaylor/huma/v2 v2.39.1
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/httplog/v3 v3.4.0
 	github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd
 	github.com/pressly/goose/v3 v3.27.3
+	github.com/prometheus/client_golang v1.23.1
 	golang.org/x/sync v0.22.0
 {%- if cookiecutter.database_choice == 'postgres' %}
 	github.com/fergusstrange/embedded-postgres v1.34.0

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -65,7 +65,7 @@ type dbConf struct {
 {% endif -%}
 
 type serverConf struct {
-	XApiKey      string        `env:"X_API_KEY,default=changeme"`
+	XApiKey      string        `env:"X_API_KEY,default="`
 	Port         int           `env:"SERVER_PORT,default=9898"`
 	TimeoutRead  time.Duration `env:"SERVER_TIMEOUT_READ,default=5s"`
 	TimeoutWrite time.Duration `env:"SERVER_TIMEOUT_WRITE,default=10s"`
@@ -180,8 +180,8 @@ func Load() (*Conf, error) {
 {% endif -%}
 
 	if c.IsProduction() {
-		if c.Server.XApiKey == "changeme" {
-			problems = append(problems, "X_API_KEY must be changed from its default in production")
+		if c.Server.XApiKey == "" {
+			problems = append(problems, "X_API_KEY must be set in production")
 		}
 {% if cookiecutter.database_choice == 'postgres' -%}
 		if c.Db.Embedded {

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -123,7 +123,7 @@ func ShouldStartEmbedded(c *Conf) bool {
 // mountedPrefixes are the paths Routes already owns. chi panics when two
 // mounts overlap, so an unlucky RIVER_UI_PATH would take the whole process
 // down at boot rather than 404 on one route.
-var mountedPrefixes = []string{"/app", "/static", "/docs", "/healthz", "/version", "/openapi.json"}
+var mountedPrefixes = []string{"/app", "/static", "/docs", "/healthz", "/version", "/metrics", "/openapi.json"}
 
 // riverUIPathProblem returns the empty string when the path is usable.
 func riverUIPathProblem(path string) string {

--- a/{{ cookiecutter.project_slug }}/internal/config/config_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config_test.go
@@ -29,6 +29,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.IsProduction() {
 		t.Error("IsProduction() = true, want false: APP_ENV defaults to development")
 	}
+	if cfg.Server.XApiKey != "" {
+		t.Errorf("XApiKey = %q, want empty by default", cfg.Server.XApiKey)
+	}
 }
 
 // One pass should be enough to fix a misconfigured deployment, rather than one
@@ -37,7 +40,7 @@ func TestLoadReportsEveryProblemAtOnce(t *testing.T) {
 	setMinimalEnv(t)
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("SERVER_PORT", "70000")
-	// X_API_KEY is left at its default, which production rejects.
+	// X_API_KEY is left empty, which production rejects.
 
 	_, err := config.Load()
 	if err == nil {

--- a/{{ cookiecutter.project_slug }}/internal/jobs/client.go
+++ b/{{ cookiecutter.project_slug }}/internal/jobs/client.go
@@ -16,9 +16,7 @@ import (
 	"strings"
 
 	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
-{% if cookiecutter.database_choice == 'postgres' -%}
 	"{{ cookiecutter.go_module_path.strip() }}/internal/store"
-{% endif -%}
 
 {% if cookiecutter.database_choice == 'postgres' -%}
 	"github.com/jackc/pgx/v5"
@@ -91,7 +89,7 @@ func NewClient(
 	cfg *config.Conf,
 	log *slog.Logger,
 ) (*Client, error) {
-	db, err := sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)")
+	db, err := sql.Open("sqlite", store.DSN(dbPath))
 	if err != nil {
 		return nil, err
 	}

--- a/{{ cookiecutter.project_slug }}/internal/metrics/metrics.go
+++ b/{{ cookiecutter.project_slug }}/internal/metrics/metrics.go
@@ -1,0 +1,81 @@
+// Package metrics owns the Prometheus registry and the application's bounded
+// HTTP metrics. Runtime and process collectors are included so a generated
+// app is useful to scrape before it has domain-specific work to measure.
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Metrics is an application-local Prometheus registry.
+type Metrics struct {
+	registry *prometheus.Registry
+	requests *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+	inFlight prometheus.Gauge
+}
+
+// New creates a registry with Go runtime, process, and HTTP server metrics.
+func New() *Metrics {
+	m := &Metrics{
+		registry: prometheus.NewRegistry(),
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "app",
+			Subsystem: "http",
+			Name:      "requests_total",
+			Help:      "Total number of HTTP requests handled.",
+		}, []string{"method", "route", "status"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "app",
+			Subsystem: "http",
+			Name:      "request_duration_seconds",
+			Help:      "HTTP request duration in seconds.",
+		}, []string{"method", "route"}),
+		inFlight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "app",
+			Subsystem: "http",
+			Name:      "requests_in_flight",
+			Help:      "Current number of HTTP requests in flight.",
+		}),
+	}
+	m.registry.MustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		m.requests,
+		m.duration,
+		m.inFlight,
+	)
+	return m
+}
+
+// Handler exposes this application's metrics in Prometheus text format.
+func (m *Metrics) Handler() http.Handler {
+	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
+}
+
+// Middleware records requests using chi's route pattern. Unmatched paths use a
+// fixed label, preventing user-controlled URLs from creating metric series.
+func (m *Metrics) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.inFlight.Inc()
+		defer m.inFlight.Dec()
+
+		captured := httpsnoop.CaptureMetrics(next, w, r)
+		route := chi.RouteContext(r.Context()).RoutePattern()
+		if route == "" {
+			route = "unmatched"
+		}
+		status := captured.Code
+		if status == 0 {
+			status = http.StatusOK
+		}
+		m.requests.WithLabelValues(r.Method, route, strconv.Itoa(status)).Inc()
+		m.duration.WithLabelValues(r.Method, route).Observe(captured.Duration.Seconds())
+	})
+}

--- a/{{ cookiecutter.project_slug }}/internal/metrics/metrics_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/metrics/metrics_test.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestMiddlewareUsesRoutePatterns(t *testing.T) {
+	m := New()
+	h := m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/items/123?secret=ignored", nil)
+	ctx := chi.NewRouteContext()
+	ctx.RoutePatterns = []string{"/items/{id}"}
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+	res := httptest.NewRecorder()
+	h.ServeHTTP(res, r)
+
+	body := httptest.NewRecorder()
+	m.Handler().ServeHTTP(body, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	text := body.Body.String()
+	if !strings.Contains(text, `app_http_requests_total{method="GET",route="/items/{id}",status="201"} 1`) {
+		t.Fatalf("metrics missing bounded route label:\n%s", text)
+	}
+	if strings.Contains(text, `route="/items/123"`) || strings.Contains(text, "secret=ignored") {
+		t.Fatalf("metrics leaked request URL values:\n%s", text)
+	}
+}

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -18,7 +18,10 @@ import (
 // config rather than the package-level loader so a test can supply its own.
 func (app *App) ApiKeyAuth(api huma.API) func(ctx huma.Context, next func(huma.Context)) {
 	return func(ctx huma.Context, next func(huma.Context)) {
-		if ctx.Header("X-API-Key") != app.Conf.Server.XApiKey {
+		// Fail closed when the operator has not configured a key. Comparing an
+		// empty header with an empty configured value would otherwise authorize
+		// every request that omitted X-API-Key.
+		if app.Conf.Server.XApiKey == "" || ctx.Header("X-API-Key") != app.Conf.Server.XApiKey {
 			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
 			return
 		}

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -67,7 +67,7 @@ func (app *App) httplogOptions() *httplog.Options {
 func (app *App) skipRequestLog(r *http.Request, _ int) bool {
 	route := chi.RouteContext(r.Context()).RoutePattern()
 	switch route {
-	case "/static/*", "/healthz":
+	case "/static/*", "/healthz", "/metrics":
 		return true
 	}
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}

--- a/{{ cookiecutter.project_slug }}/internal/server/routes.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes.go
@@ -44,6 +44,8 @@ func (app *App) Routes() http.Handler {
 	router.Use(httplog.RequestLogger(app.Log, app.httplogOptions()))
 	router.Use(middleware.Compress(5))
 	router.Use(securityHeaders)
+	router.Use(app.Metrics.Middleware)
+	router.Handle("/metrics", app.Metrics.Handler())
 
 {% if not cookiecutter.api_only -%}
 	staticFS, err := fs.Sub(assets.EmbeddedFiles, "static")

--- a/{{ cookiecutter.project_slug }}/internal/server/routes.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes.go
@@ -31,7 +31,12 @@ import (
 func (app *App) Routes() http.Handler {
 	router := chi.NewMux()
 	router.Use(middleware.RequestID)
-	router.Use(middleware.RealIP)
+	// The template cannot know which reverse proxies a generated deployment
+	// trusts. Never infer a client IP from forwarded headers by default: those
+	// headers are client-controlled when the app is directly reachable. A
+	// deployment behind a proxy must replace this with a specifically trusted
+	// ClientIPFromHeader or ClientIPFromXFF configuration.
+	router.Use(middleware.ClientIPFromRemoteAddr)
 	// Recoverer sits outside the access log purely as a backstop for httplog
 	// itself: httplog recovers handler panics first and logs them with the
 	// request and a stack trace, which Recoverer alone cannot do.

--- a/{{ cookiecutter.project_slug }}/internal/server/routes_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes_test.go
@@ -51,7 +51,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 func TestMonitoringEndpoints(t *testing.T) {
 	ts := newTestServer(t)
 
-	for _, path := range []string{"/healthz", "/version"} {
+	for _, path := range []string{"/healthz", "/version", "/metrics"} {
 		t.Run(path, func(t *testing.T) {
 			res, err := ts.Client().Get(ts.URL + path)
 			if err != nil {
@@ -60,6 +60,15 @@ func TestMonitoringEndpoints(t *testing.T) {
 			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK {
 				t.Errorf("status = %d, want 200", res.StatusCode)
+			}
+			if path == "/metrics" {
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				if !strings.Contains(string(body), "go_goroutines") {
+					t.Error("/metrics does not expose Go runtime metrics")
+				}
 			}
 		})
 	}

--- a/{{ cookiecutter.project_slug }}/internal/server/server.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
+	"{{ cookiecutter.go_module_path.strip() }}/internal/metrics"
 {% if cookiecutter.use_river -%}
 	"{{ cookiecutter.go_module_path.strip() }}/internal/jobs"
 {% endif -%}
@@ -54,6 +55,7 @@ type Deps struct {
 
 type App struct {
 	Deps
+	Metrics *metrics.Metrics
 {% if not cookiecutter.api_only -%}
 	Sessions *scs.SessionManager
 	csrf     *http.CrossOriginProtection
@@ -61,7 +63,7 @@ type App struct {
 }
 
 func New(d Deps) *App {
-	app := &App{Deps: d}
+	app := &App{Deps: d, Metrics: metrics.New()}
 {% if not cookiecutter.api_only -%}
 	app.Sessions = newSessionManager(d)
 	app.csrf = newCrossOriginProtection(d.Conf)

--- a/{{ cookiecutter.project_slug }}/internal/store/migrate.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/migrate.go
@@ -97,7 +97,7 @@ func prepareMigrationDB(ctx context.Context, dsn string, logger *slog.Logger) (*
 	}
 
 {% endif -%}
-	db, err := sql.Open("{% if cookiecutter.database_choice == 'postgres' %}pgx{% else %}sqlite{% endif %}", dsn)
+	db, err := sql.Open("{% if cookiecutter.database_choice == 'postgres' %}pgx{% else %}sqlite{% endif %}", {% if cookiecutter.database_choice == 'postgres' %}dsn{% else %}DSN(dsn){% endif %})
 	if err != nil {
 		return nil, fmt.Errorf("store: open database for migrations: %w", err)
 	}

--- a/{{ cookiecutter.project_slug }}/internal/store/pool.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/pool.go
@@ -48,16 +48,29 @@ func NewDatabasePool(ctx context.Context, cfg *config.Conf) (*pgxpool.Pool, erro
 	return pgxpool.NewWithConfig(ctx, c)
 }
 {% else -%}
+// DSN turns a database file path into a SQLite connection string with the
+// pragmas required by the application's single-writer and Litestream model.
+// busy_timeout waits for the current writer instead of returning SQLITE_BUSY,
+// WAL permits readers during writes and is required for Litestream, and
+// foreign_keys makes SQLite enforce the same relational constraints callers
+// expect from the schema.
+func DSN(path string) string {
+	return path + "?_pragma=busy_timeout(10000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+}
+
 func NewDatabasePool(ctx context.Context, cfg *config.Conf) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", cfg.Db.DbName)
+	db, err := sql.Open("sqlite", DSN(cfg.Db.DbName))
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	if err = db.PingContext(ctx); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 	return db, nil

--- a/{{ cookiecutter.project_slug }}/internal/store/sqlite_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/store/sqlite_test.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
+)
+
+func TestSQLitePoolUsesSafeDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.db")
+	t.Setenv("DATABASE_URL", path)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	db, err := NewDatabasePool(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open database pool: %v", err)
+	}
+	defer db.Close()
+
+	if got := db.Stats().MaxOpenConnections; got != 1 {
+		t.Errorf("max open connections = %d, want 1", got)
+	}
+
+	var busyTimeout int
+	if err := db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 10000 {
+		t.Errorf("busy_timeout = %d, want 10000", busyTimeout)
+	}
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Errorf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var foreignKeys int
+	if err := db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+		t.Fatalf("read foreign_keys: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Errorf("foreign_keys = %d, want 1", foreignKeys)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("database file was not created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a default `/metrics` endpoint with Go runtime, process, and HTTP metrics
- instrument bounded chi route patterns without exposing raw URLs or request data
- keep metrics scrapes out of access logs and route-prefix collision checks
- document and test the endpoint across UI and API-only variants