### PR TITLE
Ship only the controls the code implements, and define each once

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ nothing there describes a protection that does not exist.
 task dev                                  # hot-reload server, embedded database
 task test                                 # tests, no database required
 task db:migration:create -- my-migration  # new migration file
-task audit                                # lint + align + format
+task audit                                # lint + format
 task sqlc                                 # regenerate query code
 task templ                                # regenerate templates
 task clean:pg                             # reclaim embedded-Postgres leftovers

--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ CSRF uses the standard library's `http.NewCrossOriginProtection` (Go 1.25+),
 which works from `Sec-Fetch-Site`/`Origin` rather than a synchronised token, so
 forms need no hidden field. Rejected requests are answered **404, not 403**, so
 a probe cannot use the status code to confirm a route exists. Cross-origin
-callers must be listed in `TRUSTED_ORIGINS`, separated with `;` rather than
-`,` — a comma is not a separator there and ends up inside the origin.
+callers must be listed in `TRUSTED_ORIGINS`, comma separated.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ instance is skipped entirely.
 | Migrations | [goose](https://github.com/pressly/goose) (applied in-process at boot) |
 | Query gen | [sqlc](https://sqlc.dev) |
 | Jobs | [River](https://riverqueue.com) |
+| Metrics | [prometheus/client_golang](https://github.com/prometheus/client_golang), on a listener of its own |
 | Hot reload | [air](https://github.com/air-verse/air) |
 | Task runner | [task](https://taskfile.dev) |
 
@@ -141,7 +142,8 @@ CSRF uses the standard library's `http.NewCrossOriginProtection` (Go 1.25+),
 which works from `Sec-Fetch-Site`/`Origin` rather than a synchronised token, so
 forms need no hidden field. Rejected requests are answered **404, not 403**, so
 a probe cannot use the status code to confirm a route exists. Cross-origin
-callers must be listed in `TRUSTED_ORIGINS`.
+callers must be listed in `TRUSTED_ORIGINS`, separated with `;` rather than
+`,` — a comma is not a separator there and ends up inside the origin.
 
 ---
 
@@ -149,11 +151,13 @@ callers must be listed in `TRUSTED_ORIGINS`.
 
 | Value | What you get |
 |---|---|
-| `github` | `.github/workflows/ci.yml` — check → test (with the Postgres download cached) → native amd64 + arm64 image builds, no QEMU → manifest merge. |
+| `github` | `.github/workflows/ci.yml` — check → lint → test (with the Postgres download cached) → native amd64 + arm64 image builds, no QEMU → manifest merge. |
 | `woodpecker` | `.woodpecker.yml` — build, lint, test, buildx to ghcr.io, plus an optional Dokploy deploy webhook. |
 | `none` | No CI files. |
 
-Both stamp the version into the binary via `-ldflags -X`.
+Both stamp the version into the binary via `-ldflags -X`, and both run
+`golangci-lint` pinned to the same release, so neither can go green on code the
+other rejects.
 
 > [!NOTE]
 > The Woodpecker test step runs as a non-root user on a Debian image. Neither
@@ -236,11 +240,27 @@ A common pattern is both together: NATS for real-time events, River for durable 
 
 ---
 
+## Security defaults
+
+Every one of these is changeable; they are the starting position, and the
+reasoning is worth knowing before overriding it.
+
+| Default | Why |
+|---|---|
+| No in-process rate limiting | Behind a reverse proxy this binary sees the proxy's address, so an IP-keyed limiter here files every visitor into one bucket and lets the first busy client lock out the rest. Configure it at the edge, which knows the real caller. |
+| `X_API_KEY` optional, `ApiKeyAuth` attached to nothing | A UI-only project has no endpoint worth guarding, and a mandatory secret protecting nothing only teaches operators to paste junk into config. Attach the middleware when you have something to protect; it fails closed if the key is missing by then. |
+| `/metrics` on `METRICS_PORT`, never `SERVER_PORT` | It reports process statistics and enumerates every route the app answers. The Dockerfile exposes `SERVER_PORT` alone, so metrics stay reachable only from wherever the container is attached. |
+| `CLIENT_IP_SOURCE=remote` | Nothing is read from forwarded headers until a deployment names the hop it trusts, because those headers are caller-controlled whenever the process is directly reachable. Behind a proxy, set `header:` or `xff:` or every access log line records the proxy. |
+| `X-Frame-Options: DENY` and `frame-ancestors 'none'`, but no fuller CSP | Datastar compiles its `data-*` expressions with the `Function` constructor, which CSP counts as eval, so any `script-src` has to permit `'unsafe-eval'`. A policy that looks stricter than it is helps nobody; `securityHeaders` carries a working starting point in a comment. |
+| CSRF rejects with 404, not 403 | A probe cannot use the status code to confirm that a route exists. |
+
 ## Environment variables
 
 All config is via environment variables, decoded once by `config.Load`, which
-reports **every** problem at once rather than one per restart. See `.env.example`
-in the generated project for the full list.
+reports **every** problem at once rather than one per restart, and refuses to
+start on any of them. See `.env.example` in the generated project for the full
+list — everything documented there has a reader in `internal/config`, and
+nothing there describes a protection that does not exist.
 
 ---
 

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -83,10 +83,9 @@ S3_DB_URL=s3://
 SESSION_LIFETIME=168h
 # Must be true anywhere the site is served over HTTPS.
 SESSION_COOKIE_SECURE=false
-# Semicolon-separated scheme://host list of cross-origin sites allowed to
-# submit to this app -- a comma is not a separator here and lands in the origin
-# itself. Same-origin requests never need listing. Required in production.
-#   TRUSTED_ORIGINS=https://app.example.com;https://admin.example.com
+# Comma-separated scheme://host list of cross-origin sites allowed to submit
+# to this app. Same-origin requests never need listing. Required in production.
+#   TRUSTED_ORIGINS=https://app.example.com,https://admin.example.com
 TRUSTED_ORIGINS=
 {% endif -%}
 {% if cookiecutter.use_river %}

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -10,12 +10,24 @@ APP_ENV=development
 # Server
 #----------------------------------------
 SERVER_PORT=9898
+# /metrics is served here rather than on SERVER_PORT, and nothing publishes
+# this port: the Dockerfile exposes SERVER_PORT alone. Scrape it from the
+# internal network, or publish it deliberately once something authorises it.
+METRICS_PORT=9899
 SERVER_TIMEOUT_READ=5s
 SERVER_TIMEOUT_WRITE=10s
 SERVER_TIMEOUT_IDLE=15s
-# Required for any endpoint protected with ApiKeyAuth. Generate a unique
-# secret for each deployment; leaving this empty makes protected endpoints
-# reject every request.
+# Where a caller's IP is read from. This has to match the deployment: a
+# forwarded header is only trustworthy when a proxy overwrites it on every
+# request, and "remote" behind any proxy records the proxy's own address.
+#   remote            nothing sits in front of this process
+#   header:X-Real-IP  a proxy that overwrites this header unconditionally
+#   xff:10.0.0.0/8    trusted proxy CIDRs, comma separated
+CLIENT_IP_SOURCE=remote
+# Optional, and unused until you ask for it: ApiKeyAuth ships attached to no
+# operation, so nothing is protected by this key today. Once an endpoint opts
+# in, generate a unique secret per deployment -- while this is empty a guarded
+# endpoint rejects every request.
 X_API_KEY=
 
 #----------------------------------------
@@ -29,13 +41,6 @@ LOG_JSON=false
 LOG_CONCISE=false
 LOG_REQUEST_HEADERS=true
 LOG_RESPONSE_HEADERS=false
-
-#----------------------------------------
-# Rate Limiter
-#----------------------------------------
-RATE_LIMIT_ENABLED=true
-RATE_LIMIT_RPS=10
-RATE_LIMIT_BACKOFF=20s
 
 {% if cookiecutter.database_choice == 'postgres' -%}
 #----------------------------------------
@@ -78,8 +83,10 @@ S3_DB_URL=s3://
 SESSION_LIFETIME=168h
 # Must be true anywhere the site is served over HTTPS.
 SESSION_COOKIE_SECURE=false
-# Comma-separated scheme://host list of cross-origin sites allowed to submit
-# to this app. Same-origin requests never need listing. Required in production.
+# Semicolon-separated scheme://host list of cross-origin sites allowed to
+# submit to this app -- a comma is not a separator here and lands in the origin
+# itself. Same-origin requests never need listing. Required in production.
+#   TRUSTED_ORIGINS=https://app.example.com;https://admin.example.com
 TRUSTED_ORIGINS=
 {% endif -%}
 {% if cookiecutter.use_river %}

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -41,6 +41,28 @@ jobs:
       - run: go build ./...
       - run: go vet ./...
 
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Generate templ
+        run: |
+          if ls internal/ui/templates/*.templ >/dev/null 2>&1; then
+            go tool templ generate
+          fi
+
+      # Pinned to the release .woodpecker.yml runs, so the two CI choices
+      # cannot disagree about whether this code passes.
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          args: ./... --config=.golangci.yml
+
   test:
     runs-on: ubuntu-24.04
     steps:
@@ -76,7 +98,7 @@ jobs:
           fi
 
   image:
-    needs: [check, test]
+    needs: [check, lint, test]
     if: github.event_name == 'push'
     permissions:
       contents: read

--- a/{{ cookiecutter.project_slug }}/.golangci.yml
+++ b/{{ cookiecutter.project_slug }}/.golangci.yml
@@ -8,3 +8,16 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+  settings:
+    errcheck:
+      # Close is excluded as a category rather than silenced at each call
+      # site. Every one here is a database handle, a listener or a response
+      # body, where the close error reports on work that has already
+      # finished and there is nothing left to do about it. Reinstate the
+      # check if something starts closing a file it just wrote, where a
+      # failed close does lose data.
+      exclude-functions:
+        - (io.Closer).Close
+        - (net.Listener).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Conn).Close

--- a/{{ cookiecutter.project_slug }}/CLAUDE.md
+++ b/{{ cookiecutter.project_slug }}/CLAUDE.md
@@ -54,7 +54,10 @@ file: it is generated and gitignored.
 ## Conventions
 
 - **Configuration** is environment-only, decoded once in `config.Load`. Add a
-  field with an `env:` tag; never read `os.Getenv` from application code.
+  field with an `env:` tag; never read `os.Getenv` from application code. A
+  setting that nothing reads is worse than a missing one — it claims a
+  behaviour the code does not have — so add the reader in the same change, and
+  validate the value in `Load` where the problem joins all the others.
 - **Errors** use `errors.Is`/`errors.As`, never `err ==`. Wrap with a package
   prefix: `fmt.Errorf("boards: create: %w", err)`.
 - **Logging** is `slog`. A record logged with a request context carries

--- a/{{ cookiecutter.project_slug }}/CLAUDE.md
+++ b/{{ cookiecutter.project_slug }}/CLAUDE.md
@@ -15,7 +15,7 @@ is the context every other decision is judged against._
 ```shell
 task dev     # hot-reload server{% if cookiecutter.database_choice == 'postgres' %}; starts its own Postgres{% endif %}
 task test    # no database required
-task audit   # lint, align, format
+task audit   # lint, format
 ```
 
 Do **not** build a binary to check your work — `task dev` is already running

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -179,7 +179,7 @@ missing resource still warns.
 Pages are [templ](https://templ.guide) templates updated in place by
 [Datastar](https://data-star.dev). Cross-origin writes are rejected by
 `http.CrossOriginProtection`; list any legitimate cross-origin callers in
-`TRUSTED_ORIGINS`, separated with `;` rather than `,`.
+`TRUSTED_ORIGINS`, comma separated.
 {% else %}
 ## HTTP surface
 

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -168,7 +168,6 @@ missing resource still warns.
 | Path | What |
 |---|---|
 | `/healthz`, `/version` | Monitoring, also in the OpenAPI spec |
-| `/metrics` | Prometheus runtime, process, and HTTP metrics |
 | `/docs`, `/openapi.json` | API reference |
 | `/app` | The rendered UI |
 | `/app/welcome` | First-run tour of what was scaffolded — delete when it has served its purpose |
@@ -180,16 +179,58 @@ missing resource still warns.
 Pages are [templ](https://templ.guide) templates updated in place by
 [Datastar](https://data-star.dev). Cross-origin writes are rejected by
 `http.CrossOriginProtection`; list any legitimate cross-origin callers in
-`TRUSTED_ORIGINS`.
+`TRUSTED_ORIGINS`, separated with `;` rather than `,`.
 {% else %}
 ## HTTP surface
 
 | Path | What |
 |---|---|
 | `/healthz`, `/version` | Monitoring |
-| `/metrics` | Prometheus runtime, process, and HTTP metrics |
 | `/docs`, `/openapi.json` | API reference |
 {% endif %}
+## Security headers
+
+Every response carries `Referrer-Policy: no-referrer`, `X-Content-Type-Options:
+nosniff`, `X-Frame-Options: DENY` and `Content-Security-Policy:
+frame-ancestors 'none'`. There is no fuller CSP by default{% if not cookiecutter.api_only %}: Datastar
+evaluates its `data-*` expressions through the `Function` constructor, so any
+`script-src` has to permit `'unsafe-eval'`, and a policy that looks stricter
+than it is helps nobody. `securityHeaders` in `internal/server/routes.go`
+carries a working starting point in a comment{% endif %}.
+
+## API authentication
+
+`ApiKeyAuth` compares an `X-API-Key` header against `X_API_KEY` and is attached
+to nothing: a freshly generated project has no endpoint worth guarding. The
+scheme is declared in the OpenAPI document so it is ready to reference, and
+`registerEndpoints` in `internal/server/routes.go` shows where the gate goes.
+Until then no key is required, in production or anywhere else.
+
+## Metrics
+
+Prometheus runtime, process and HTTP metrics are served at `/metrics` on
+`METRICS_PORT`, not on `SERVER_PORT`. They sit on a separate listener because
+they describe the process and enumerate every route it answers, which is worth
+handing an operator and nobody else. The Dockerfile exposes `SERVER_PORT`
+alone, so the metrics port is reachable only from wherever the container is
+attached.
+
+## Client addresses
+
+`CLIENT_IP_SOURCE` decides what the access log and anything else calling
+`middleware.GetClientIP` treats as the caller: `remote` for a process reachable
+directly, `header:X-Real-IP` for a proxy that overwrites that header on every
+request, or `xff:<cidr>[,<cidr>...]` naming the proxy hops to walk past. Leaving
+it on `remote` behind a proxy records the proxy on every line.
+
+## Rate limiting
+
+Not done in this process. Behind a reverse proxy the binary sees the proxy's
+address rather than the caller's, so an IP-keyed limiter here would file every
+visitor into one bucket and let the first busy client lock out the rest.
+Configure it at the edge instead -- Traefik, Caddy and nginx all limit on the
+address they terminate.
+
 ## Container
 
 ```shell

--- a/{{ cookiecutter.project_slug }}/Taskfile.yaml
+++ b/{{ cookiecutter.project_slug }}/Taskfile.yaml
@@ -173,16 +173,10 @@ vars:
       - goose -dir ./assets/migrations {{.DB_TYPE}} "{{.GOOSE_DSN}}" status
 
   audit:
-    desc: Run linters and betteralign
+    desc: Run linters and formatters
     cmds:
-      - task: betteralign
       - task: golines
       - task: golangci
-
-  betteralign:
-    desc: Run betteralign
-    cmds:
-      - betteralign -apply ./... {{.CLI_ARGS}}
 
   golangci:
     desc: Run golangci-lint
@@ -212,7 +206,6 @@ vars:
       - go install github.com/air-verse/air@latest
       - go install github.com/go-task/task/v3/cmd/task@latest
       - go install github.com/segmentio/golines@latest
-      - go install github.com/dkorunic/betteralign/cmd/betteralign@latest
       - go install mvdan.cc/gofumpt@latest
       - go install github.com/danielgtaylor/restish@latest
 {% endraw %}{% if cookiecutter.use_tailwind and not cookiecutter.api_only %}      # tailwindcss is a standalone binary, not a Go tool:

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.postgres
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.postgres
@@ -51,6 +51,8 @@ FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder ["/out/app", "/usr/bin/app"]
 
 ENV DOCKER=1
+# SERVER_PORT only. METRICS_PORT is deliberately absent: nothing in front of
+# it authorises anything, so it stays reachable only on the container network.
 EXPOSE 9898
 
 # A distroless image has no curl or shell, so the binary probes itself.

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.sqlite
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.sqlite
@@ -58,6 +58,8 @@ COPY --from=builder ["/out/app", "/usr/bin/app"]
 COPY ["litestream.yml", "/etc/litestream.yml"]
 
 ENV DOCKER=1
+# SERVER_PORT only. METRICS_PORT is deliberately absent: nothing in front of
+# it authorises anything, so it stays reachable only on the container network.
 EXPOSE 9898
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/{{ cookiecutter.project_slug }}/internal/cmd/serve_cmd.go
+++ b/{{ cookiecutter.project_slug }}/internal/cmd/serve_cmd.go
@@ -51,6 +51,10 @@ func (s *ServeCmd) Run() error {
 	if err := exampleSubscriber.Subscribe(app.Ctx); err != nil {
 		return fmt.Errorf("subscribe to example messages: %w", err)
 	}
+	// The process is on its way out and the connection close above tears the
+	// subscription down regardless, so a failed unsubscribe has nothing left
+	// to act on.
+	//nolint:errcheck
 	defer exampleSubscriber.Unsubscribe()
 
 	deps.Nats = natsConn

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -88,6 +88,24 @@ type sessionConf struct {
 	// Secure must be true anywhere the site is served over HTTPS.
 	Secure bool `env:"SESSION_COOKIE_SECURE,default=false"`
 }
+
+// originList is a comma-separated list of origins.
+//
+// It parses itself because envdecode splits a plain []string on semicolons,
+// which is not the separator anyone reaches for: a second origin written the
+// expected way became part of the first and was rejected as one unparseable
+// value. envdecode prefers a TextUnmarshaler over its own slice handling, so
+// declaring one is enough to take the decision back.
+type originList []string
+
+func (o *originList) UnmarshalText(text []byte) error {
+	for _, entry := range strings.Split(string(text), ",") {
+		if origin := strings.TrimSpace(entry); origin != "" {
+			*o = append(*o, origin)
+		}
+	}
+	return nil
+}
 {% endif -%}
 
 type appConf struct {
@@ -100,7 +118,7 @@ type appConf struct {
 {% if not cookiecutter.api_only -%}
 	// TrustedOrigins are the cross-origin sites allowed to submit to this app,
 	// as scheme://host (e.g. https://app.example.com).
-	TrustedOrigins []string `env:"TRUSTED_ORIGINS"`
+	TrustedOrigins originList `env:"TRUSTED_ORIGINS"`
 {% endif -%}
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}
 	// RiverUIEnabled mounts the job dashboard inside this binary. It ships off
@@ -240,12 +258,6 @@ func Load() (*Conf, error) {
 	for _, origin := range c.AppConf.TrustedOrigins {
 		if err := csrf.AddTrustedOrigin(origin); err != nil {
 			problems = append(problems, fmt.Sprintf("TRUSTED_ORIGINS: %v", err))
-			if strings.Contains(origin, ",") {
-				problems = append(
-					problems,
-					"TRUSTED_ORIGINS separates entries with ';', not ','",
-				)
-			}
 		}
 	}
 {% endif -%}

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 {% if not cookiecutter.api_only -%}
 	"net/http"
 {% endif -%}
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -99,12 +100,22 @@ type sessionConf struct {
 type originList []string
 
 func (o *originList) UnmarshalText(text []byte) error {
-	for _, entry := range strings.Split(string(text), ",") {
-		if origin := strings.TrimSpace(entry); origin != "" {
-			*o = append(*o, origin)
+	*o = splitList(string(text))
+	return nil
+}
+
+// NewCrossOriginProtection builds the stdlib CSRF check, reporting the entries
+// it refused rather than failing on the first. Load and the server both build
+// it from here, so neither can accept an origin the other rejects.
+func NewCrossOriginProtection(origins []string) (*http.CrossOriginProtection, []string) {
+	p := http.NewCrossOriginProtection()
+	var problems []string
+	for _, origin := range origins {
+		if err := p.AddTrustedOrigin(origin); err != nil {
+			problems = append(problems, fmt.Sprintf("TRUSTED_ORIGINS: %v", err))
 		}
 	}
-	return nil
+	return p, problems
 }
 {% endif -%}
 
@@ -169,38 +180,76 @@ func riverUIPathProblem(path string) string {
 }
 
 {% endif -%}
-// clientIPSourceProblem returns the empty string when the source is usable.
+// splitList splits a comma-separated environment value, dropping surrounding
+// space and empty entries.
+func splitList(s string) []string {
+	var out []string
+	for _, entry := range strings.Split(s, ",") {
+		if v := strings.TrimSpace(entry); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// CLIENT_IP_SOURCE modes, spelled as they are written in the environment.
+const (
+	ClientIPRemote = "remote"
+	ClientIPHeader = "header"
+	ClientIPXFF    = "xff"
+)
+
+// ClientIPSource is CLIENT_IP_SOURCE parsed into the argument its middleware
+// needs. Only Mode is always set; Header and Prefixes belong to one mode each.
+type ClientIPSource struct {
+	Mode     string
+	Header   string
+	Prefixes []string
+}
+
+// ParseClientIPSource parses CLIENT_IP_SOURCE. Load reports the error beside
+// every other configuration problem and the router wires the result, so the
+// grammar is defined once and the two cannot drift.
 //
 // Prefixes are parsed here rather than left to chi, whose XFF middleware
 // builds them with netip.MustParsePrefix and would take the process down at
 // boot instead of reporting the typo.
-func clientIPSourceProblem(source string) string {
+func ParseClientIPSource(source string) (ClientIPSource, error) {
 	mode, arg, _ := strings.Cut(source, ":")
 	switch mode {
-	case "remote":
+	case ClientIPRemote:
 		if arg != "" {
-			return "CLIENT_IP_SOURCE=remote takes no argument"
+			return ClientIPSource{}, errors.New("CLIENT_IP_SOURCE=remote takes no argument")
 		}
-	case "header":
+		return ClientIPSource{Mode: mode}, nil
+	case ClientIPHeader:
 		if arg == "" {
-			return "CLIENT_IP_SOURCE=header needs a header name, e.g. header:X-Real-IP"
+			return ClientIPSource{}, errors.New(
+				"CLIENT_IP_SOURCE=header needs a header name, e.g. header:X-Real-IP",
+			)
 		}
-	case "xff":
-		if arg == "" {
-			return "CLIENT_IP_SOURCE=xff needs at least one trusted CIDR, e.g. xff:10.0.0.0/8"
+		return ClientIPSource{Mode: mode, Header: arg}, nil
+	case ClientIPXFF:
+		prefixes := splitList(arg)
+		if len(prefixes) == 0 {
+			return ClientIPSource{}, errors.New(
+				"CLIENT_IP_SOURCE=xff needs at least one trusted CIDR, e.g. xff:10.0.0.0/8",
+			)
 		}
-		for _, cidr := range strings.Split(arg, ",") {
-			if _, err := netip.ParsePrefix(strings.TrimSpace(cidr)); err != nil {
-				return fmt.Sprintf("CLIENT_IP_SOURCE has an unparseable CIDR %q", cidr)
+		for _, cidr := range prefixes {
+			if _, err := netip.ParsePrefix(cidr); err != nil {
+				return ClientIPSource{}, fmt.Errorf(
+					"CLIENT_IP_SOURCE has an unparseable CIDR %q",
+					cidr,
+				)
 			}
 		}
-	default:
-		return fmt.Sprintf(
-			"CLIENT_IP_SOURCE %q must be remote, header:<Name>, or xff:<cidr>[,<cidr>...]",
-			source,
-		)
+		return ClientIPSource{Mode: mode, Prefixes: prefixes}, nil
 	}
-	return ""
+	return ClientIPSource{}, fmt.Errorf(
+		"CLIENT_IP_SOURCE %q must be remote, header:<Name>, or xff:<cidr>[,<cidr>...]",
+		source,
+	)
 }
 
 // Load reads configuration from the environment.
@@ -230,8 +279,8 @@ func Load() (*Conf, error) {
 	if c.Server.Port < 1 || c.Server.Port > 65535 {
 		problems = append(problems, "SERVER_PORT must be between 1 and 65535")
 	}
-	if problem := clientIPSourceProblem(c.Server.ClientIPSource); problem != "" {
-		problems = append(problems, problem)
+	if _, err := ParseClientIPSource(c.Server.ClientIPSource); err != nil {
+		problems = append(problems, err.Error())
 	}
 	if c.Server.MetricsPort < 1 || c.Server.MetricsPort > 65535 {
 		problems = append(problems, "METRICS_PORT must be between 1 and 65535")
@@ -251,37 +300,31 @@ func Load() (*Conf, error) {
 {% endif -%}
 
 {% if not cookiecutter.api_only -%}
-	// Checked here rather than where CrossOriginProtection is built, so a typo
-	// is reported beside every other problem instead of ending the process
-	// with a stack trace before anything has started.
-	csrf := http.NewCrossOriginProtection()
-	for _, origin := range c.AppConf.TrustedOrigins {
-		if err := csrf.AddTrustedOrigin(origin); err != nil {
-			problems = append(problems, fmt.Sprintf("TRUSTED_ORIGINS: %v", err))
-		}
-	}
+	// Built here as well as where it is used, so a typo is reported beside
+	// every other problem instead of ending the process with a stack trace
+	// before anything has started.
+	_, originProblems := NewCrossOriginProtection(c.AppConf.TrustedOrigins)
+	problems = append(problems, originProblems...)
 {% endif -%}
 
-{# Postgres and the UI supply every check inside this block, so a SQLite
-   api_only build would render it empty and trip staticcheck SA9003. #}
-{% if cookiecutter.database_choice == 'postgres' or not cookiecutter.api_only -%}
-	if c.IsProduction() {
+{# Each check guards itself. One shared `if c.IsProduction()` would render
+   empty for a SQLite api_only build -- staticcheck SA9003 -- and its Jinja
+   condition would be a second copy of the guards below, silently dropping any
+   later check that did not happen to match it. #}
 {% if cookiecutter.database_choice == 'postgres' -%}
-		if c.Db.Embedded {
-			problems = append(
-				problems,
-				"EMBEDDED_POSTGRES must be false in production; supply DATABASE_URL instead",
-			)
-		}
+	if c.IsProduction() && c.Db.Embedded {
+		problems = append(
+			problems,
+			"EMBEDDED_POSTGRES must be false in production; supply DATABASE_URL instead",
+		)
+	}
 {% endif -%}
 {% if not cookiecutter.api_only -%}
-		if len(c.AppConf.TrustedOrigins) == 0 {
-			problems = append(problems, "TRUSTED_ORIGINS must list at least one origin in production")
-		}
-		if !c.Session.Secure {
-			problems = append(problems, "SESSION_COOKIE_SECURE must be true in production")
-		}
-{% endif -%}
+	if c.IsProduction() && len(c.AppConf.TrustedOrigins) == 0 {
+		problems = append(problems, "TRUSTED_ORIGINS must list at least one origin in production")
+	}
+	if c.IsProduction() && !c.Session.Secure {
+		problems = append(problems, "SESSION_COOKIE_SECURE must be true in production")
 	}
 {% endif -%}
 

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -250,6 +250,9 @@ func Load() (*Conf, error) {
 	}
 {% endif -%}
 
+{# Postgres and the UI supply every check inside this block, so a SQLite
+   api_only build would render it empty and trip staticcheck SA9003. #}
+{% if cookiecutter.database_choice == 'postgres' or not cookiecutter.api_only -%}
 	if c.IsProduction() {
 {% if cookiecutter.database_choice == 'postgres' -%}
 		if c.Db.Embedded {
@@ -268,6 +271,7 @@ func Load() (*Conf, error) {
 		}
 {% endif -%}
 	}
+{% endif -%}
 
 	if len(problems) > 0 {
 		return nil, fmt.Errorf("config:\n  - %s", strings.Join(problems, "\n  - "))

--- a/{{ cookiecutter.project_slug }}/internal/config/config.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config.go
@@ -1,8 +1,12 @@
 package config
 
 import (
+{% if not cookiecutter.api_only -%}
+	"net/http"
+{% endif -%}
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -16,7 +20,6 @@ const EnvProduction = "production"
 type Conf struct {
 	Server  serverConf
 	Db      dbConf
-	Limiter limiter
 	AppConf appConf
 {% if not cookiecutter.api_only -%}
 	Session sessionConf
@@ -24,12 +27,6 @@ type Conf struct {
 {% if cookiecutter.use_nats -%}
 	Nats natsConf
 {% endif -%}
-}
-
-type limiter struct {
-	Enabled bool          `env:"RATE_LIMIT_ENABLED,default=true"`
-	Rps     int           `env:"RATE_LIMIT_RPS,default=10"`
-	BackOff time.Duration `env:"RATE_LIMIT_BACKOFF,default=20s"`
 }
 
 {% if cookiecutter.use_nats -%}
@@ -67,9 +64,19 @@ type dbConf struct {
 type serverConf struct {
 	XApiKey      string        `env:"X_API_KEY,default="`
 	Port         int           `env:"SERVER_PORT,default=9898"`
+	// MetricsPort carries /metrics on a listener of its own so the interface
+	// serving it can be kept off the public network. Nothing publishes it:
+	// the Dockerfile exposes SERVER_PORT alone.
+	MetricsPort  int           `env:"METRICS_PORT,default=9899"`
 	TimeoutRead  time.Duration `env:"SERVER_TIMEOUT_READ,default=5s"`
 	TimeoutWrite time.Duration `env:"SERVER_TIMEOUT_WRITE,default=10s"`
 	TimeoutIdle  time.Duration `env:"SERVER_TIMEOUT_IDLE,default=15s"`
+	// ClientIPSource decides where a caller's address is read from: remote,
+	// header:<Name>, or xff:<cidr>[,<cidr>...]. It has to match the
+	// deployment. A header is only as trustworthy as the proxy that
+	// overwrites it on every request, and remote behind any proxy yields the
+	// proxy's own address rather than the caller's.
+	ClientIPSource string `env:"CLIENT_IP_SOURCE,default=remote"`
 }
 
 {% if not cookiecutter.api_only -%}
@@ -123,7 +130,7 @@ func ShouldStartEmbedded(c *Conf) bool {
 // mountedPrefixes are the paths Routes already owns. chi panics when two
 // mounts overlap, so an unlucky RIVER_UI_PATH would take the whole process
 // down at boot rather than 404 on one route.
-var mountedPrefixes = []string{"/app", "/static", "/docs", "/healthz", "/version", "/metrics", "/openapi.json"}
+var mountedPrefixes = []string{"/app", "/static", "/docs", "/healthz", "/version", "/openapi.json"}
 
 // riverUIPathProblem returns the empty string when the path is usable.
 func riverUIPathProblem(path string) string {
@@ -144,6 +151,40 @@ func riverUIPathProblem(path string) string {
 }
 
 {% endif -%}
+// clientIPSourceProblem returns the empty string when the source is usable.
+//
+// Prefixes are parsed here rather than left to chi, whose XFF middleware
+// builds them with netip.MustParsePrefix and would take the process down at
+// boot instead of reporting the typo.
+func clientIPSourceProblem(source string) string {
+	mode, arg, _ := strings.Cut(source, ":")
+	switch mode {
+	case "remote":
+		if arg != "" {
+			return "CLIENT_IP_SOURCE=remote takes no argument"
+		}
+	case "header":
+		if arg == "" {
+			return "CLIENT_IP_SOURCE=header needs a header name, e.g. header:X-Real-IP"
+		}
+	case "xff":
+		if arg == "" {
+			return "CLIENT_IP_SOURCE=xff needs at least one trusted CIDR, e.g. xff:10.0.0.0/8"
+		}
+		for _, cidr := range strings.Split(arg, ",") {
+			if _, err := netip.ParsePrefix(strings.TrimSpace(cidr)); err != nil {
+				return fmt.Sprintf("CLIENT_IP_SOURCE has an unparseable CIDR %q", cidr)
+			}
+		}
+	default:
+		return fmt.Sprintf(
+			"CLIENT_IP_SOURCE %q must be remote, header:<Name>, or xff:<cidr>[,<cidr>...]",
+			source,
+		)
+	}
+	return ""
+}
+
 // Load reads configuration from the environment.
 //
 // Every problem is reported at once rather than one per restart: a
@@ -171,6 +212,18 @@ func Load() (*Conf, error) {
 	if c.Server.Port < 1 || c.Server.Port > 65535 {
 		problems = append(problems, "SERVER_PORT must be between 1 and 65535")
 	}
+	if problem := clientIPSourceProblem(c.Server.ClientIPSource); problem != "" {
+		problems = append(problems, problem)
+	}
+	if c.Server.MetricsPort < 1 || c.Server.MetricsPort > 65535 {
+		problems = append(problems, "METRICS_PORT must be between 1 and 65535")
+	}
+	if c.Server.MetricsPort == c.Server.Port {
+		problems = append(
+			problems,
+			"METRICS_PORT must differ from SERVER_PORT; both listeners cannot share one port",
+		)
+	}
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}
 	if c.AppConf.RiverUIEnabled {
 		if problem := riverUIPathProblem(c.AppConf.RiverUIPath); problem != "" {
@@ -179,10 +232,25 @@ func Load() (*Conf, error) {
 	}
 {% endif -%}
 
-	if c.IsProduction() {
-		if c.Server.XApiKey == "" {
-			problems = append(problems, "X_API_KEY must be set in production")
+{% if not cookiecutter.api_only -%}
+	// Checked here rather than where CrossOriginProtection is built, so a typo
+	// is reported beside every other problem instead of ending the process
+	// with a stack trace before anything has started.
+	csrf := http.NewCrossOriginProtection()
+	for _, origin := range c.AppConf.TrustedOrigins {
+		if err := csrf.AddTrustedOrigin(origin); err != nil {
+			problems = append(problems, fmt.Sprintf("TRUSTED_ORIGINS: %v", err))
+			if strings.Contains(origin, ",") {
+				problems = append(
+					problems,
+					"TRUSTED_ORIGINS separates entries with ';', not ','",
+				)
+			}
 		}
+	}
+{% endif -%}
+
+	if c.IsProduction() {
 {% if cookiecutter.database_choice == 'postgres' -%}
 		if c.Db.Embedded {
 			problems = append(

--- a/{{ cookiecutter.project_slug }}/internal/config/config_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config_test.go
@@ -116,30 +116,17 @@ func TestTrustedOriginsValidated(t *testing.T) {
 
 func TestTrustedOriginsAccepted(t *testing.T) {
 	setMinimalEnv(t)
-	t.Setenv("TRUSTED_ORIGINS", "https://a.example;https://b.example:8443;http://localhost:3000")
+	t.Setenv("TRUSTED_ORIGINS", "https://a.example, https://b.example:8443 ,http://localhost:3000")
 
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatalf("valid origins rejected: %v", err)
 	}
 	if len(cfg.AppConf.TrustedOrigins) != 3 {
-		t.Errorf("TrustedOrigins = %v, want 3 entries", cfg.AppConf.TrustedOrigins)
+		t.Fatalf("TrustedOrigins = %v, want 3 entries", cfg.AppConf.TrustedOrigins)
 	}
-}
-
-// envdecode splits lists on semicolons while every neighbouring tool uses
-// commas, so the likely mistake is named instead of surfacing as one very long
-// unparseable origin.
-func TestTrustedOriginsNamesTheSeparator(t *testing.T) {
-	setMinimalEnv(t)
-	t.Setenv("TRUSTED_ORIGINS", "https://a.example,https://b.example")
-
-	_, err := config.Load()
-	if err == nil {
-		t.Fatal("comma-separated origins accepted, want rejected")
-	}
-	if !strings.Contains(err.Error(), "';'") {
-		t.Errorf("error does not point at the separator:\n%v", err)
+	if got := cfg.AppConf.TrustedOrigins[1]; got != "https://b.example:8443" {
+		t.Errorf("entry 1 = %q, want the surrounding space trimmed", got)
 	}
 }
 {% endif -%}

--- a/{{ cookiecutter.project_slug }}/internal/config/config_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/config/config_test.go
@@ -32,24 +32,156 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Server.XApiKey != "" {
 		t.Errorf("XApiKey = %q, want empty by default", cfg.Server.XApiKey)
 	}
+	if cfg.Server.ClientIPSource != "remote" {
+		t.Errorf("ClientIPSource = %q, want remote by default", cfg.Server.ClientIPSource)
+	}
+	if cfg.Server.MetricsPort == cfg.Server.Port {
+		t.Errorf("MetricsPort = %d, want a port of its own", cfg.Server.MetricsPort)
+	}
+}
+
+func TestMetricsPortValidated(t *testing.T) {
+	setMinimalEnv(t)
+	t.Setenv("METRICS_PORT", "70000")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("METRICS_PORT=70000 accepted, want rejected")
+	}
+	if !strings.Contains(err.Error(), "METRICS_PORT") {
+		t.Errorf("error does not mention METRICS_PORT:\n%v", err)
+	}
 }
 
 // One pass should be enough to fix a misconfigured deployment, rather than one
 // restart per missing variable.
 func TestLoadReportsEveryProblemAtOnce(t *testing.T) {
 	setMinimalEnv(t)
-	t.Setenv("APP_ENV", "production")
 	t.Setenv("SERVER_PORT", "70000")
-	// X_API_KEY is left empty, which production rejects.
+	t.Setenv("METRICS_PORT", "0")
 
 	_, err := config.Load()
 	if err == nil {
-		t.Fatal("Load() = nil error, want the production problems reported")
+		t.Fatal("Load() = nil error, want both problems reported")
 	}
-	for _, want := range []string{"SERVER_PORT", "X_API_KEY"} {
+	for _, want := range []string{"SERVER_PORT", "METRICS_PORT"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error does not mention %s:\n%v", want, err)
 		}
+	}
+}
+
+// An API key protects nothing until an operation opts into ApiKeyAuth, so a
+// deployment that never wires it must not be made to invent a secret.
+func TestProductionDoesNotRequireApiKey(t *testing.T) {
+	setMinimalEnv(t)
+	t.Setenv("APP_ENV", "production")
+{% if cookiecutter.database_choice == 'postgres' -%}
+	t.Setenv("EMBEDDED_POSTGRES", "false")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost:5432/app")
+{% endif -%}
+{% if not cookiecutter.api_only -%}
+	t.Setenv("SESSION_COOKIE_SECURE", "true")
+{% endif -%}
+
+	if _, err := config.Load(); err != nil {
+		t.Fatalf("production rejected with no X_API_KEY set: %v", err)
+	}
+}
+{% if not cookiecutter.api_only %}
+// A malformed origin is a typo in an environment variable, so it belongs in
+// the same list as every other problem rather than taking the process down
+// with a stack trace at boot.
+func TestTrustedOriginsValidated(t *testing.T) {
+	for _, origin := range []string{
+		"example.com",
+		"https://x.example/path",
+		"https://x.example?a=b",
+		"://x.example",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			setMinimalEnv(t)
+			t.Setenv("TRUSTED_ORIGINS", origin)
+
+			_, err := config.Load()
+			if err == nil {
+				t.Fatalf("TRUSTED_ORIGINS=%q accepted, want rejected", origin)
+			}
+			if !strings.Contains(err.Error(), "TRUSTED_ORIGINS") {
+				t.Errorf("error does not mention TRUSTED_ORIGINS:\n%v", err)
+			}
+		})
+	}
+}
+
+func TestTrustedOriginsAccepted(t *testing.T) {
+	setMinimalEnv(t)
+	t.Setenv("TRUSTED_ORIGINS", "https://a.example;https://b.example:8443;http://localhost:3000")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("valid origins rejected: %v", err)
+	}
+	if len(cfg.AppConf.TrustedOrigins) != 3 {
+		t.Errorf("TrustedOrigins = %v, want 3 entries", cfg.AppConf.TrustedOrigins)
+	}
+}
+
+// envdecode splits lists on semicolons while every neighbouring tool uses
+// commas, so the likely mistake is named instead of surfacing as one very long
+// unparseable origin.
+func TestTrustedOriginsNamesTheSeparator(t *testing.T) {
+	setMinimalEnv(t)
+	t.Setenv("TRUSTED_ORIGINS", "https://a.example,https://b.example")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("comma-separated origins accepted, want rejected")
+	}
+	if !strings.Contains(err.Error(), "';'") {
+		t.Errorf("error does not point at the separator:\n%v", err)
+	}
+}
+{% endif -%}
+
+// chi builds the XFF middleware with netip.MustParsePrefix and panics at boot
+// on a bad prefix, so an unusable source has to be caught during Load.
+func TestClientIPSourceRejected(t *testing.T) {
+	for _, source := range []string{
+		"bogus",
+		"remote:x",
+		"header:",
+		"xff:",
+		"xff:not-a-cidr",
+		"xff:10.0.0.0/8,nonsense",
+	} {
+		t.Run(source, func(t *testing.T) {
+			setMinimalEnv(t)
+			t.Setenv("CLIENT_IP_SOURCE", source)
+
+			if _, err := config.Load(); err == nil {
+				t.Errorf("CLIENT_IP_SOURCE=%q accepted, want rejected", source)
+			}
+		})
+	}
+}
+
+func TestClientIPSourceAccepted(t *testing.T) {
+	for _, source := range []string{
+		"remote",
+		"header:X-Real-IP",
+		"xff:10.0.0.0/8",
+		"xff:10.0.0.0/8,172.16.0.0/12",
+		"xff:2600:9000::/28",
+	} {
+		t.Run(source, func(t *testing.T) {
+			setMinimalEnv(t)
+			t.Setenv("CLIENT_IP_SOURCE", source)
+
+			if _, err := config.Load(); err != nil {
+				t.Errorf("CLIENT_IP_SOURCE=%q rejected: %v", source, err)
+			}
+		})
 	}
 }
 {% if cookiecutter.use_river and not cookiecutter.api_only %}

--- a/{{ cookiecutter.project_slug }}/internal/metrics/metrics.go
+++ b/{{ cookiecutter.project_slug }}/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/felixge/httpsnoop"
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -45,8 +46,8 @@ func New() *Metrics {
 		}),
 	}
 	m.registry.MustRegister(
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		m.requests,
 		m.duration,
 		m.inFlight,

--- a/{{ cookiecutter.project_slug }}/internal/metrics/metrics_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/metrics/metrics_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+func TestHandlerExposesRuntimeMetrics(t *testing.T) {
+	m := New()
+
+	res := httptest.NewRecorder()
+	m.Handler().ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if !strings.Contains(res.Body.String(), "go_goroutines") {
+		t.Errorf("handler does not expose Go runtime metrics:\n%s", res.Body.String())
+	}
+}
+
 func TestMiddlewareUsesRoutePatterns(t *testing.T) {
 	m := New()
 	h := m.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -19,17 +19,14 @@ import (
 // config rather than the package-level loader so a test can supply its own.
 func (app *App) ApiKeyAuth(api huma.API) func(ctx huma.Context, next func(huma.Context)) {
 	return func(ctx huma.Context, next func(huma.Context)) {
-		// Fail closed when the operator has not configured a key. Comparing an
-		// empty header with an empty configured value would otherwise authorize
-		// every request that omitted X-API-Key.
+		// The empty check comes first because ConstantTimeCompare reports two
+		// empty slices as equal: without it an unconfigured key would
+		// authorize every request that omitted the header. The comparison
+		// itself is constant time so how long a rejection takes cannot tell
+		// the caller how much of the key they guessed correctly.
 		key := app.Conf.Server.XApiKey
-		if key == "" {
-			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		// Constant time: how long a rejection takes must not tell the caller
-		// how much of the key they guessed correctly.
-		if subtle.ConstantTimeCompare([]byte(ctx.Header("X-API-Key")), []byte(key)) != 1 {
+		if key == "" ||
+			subtle.ConstantTimeCompare([]byte(ctx.Header("X-API-Key")), []byte(key)) != 1 {
 			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
 			return
 		}

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware.go
@@ -4,6 +4,7 @@ import (
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}
 	"strings"
 {% endif -%}
+	"crypto/subtle"
 	"log/slog"
 	"net/http"
 
@@ -21,7 +22,14 @@ func (app *App) ApiKeyAuth(api huma.API) func(ctx huma.Context, next func(huma.C
 		// Fail closed when the operator has not configured a key. Comparing an
 		// empty header with an empty configured value would otherwise authorize
 		// every request that omitted X-API-Key.
-		if app.Conf.Server.XApiKey == "" || ctx.Header("X-API-Key") != app.Conf.Server.XApiKey {
+		key := app.Conf.Server.XApiKey
+		if key == "" {
+			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		// Constant time: how long a rejection takes must not tell the caller
+		// how much of the key they guessed correctly.
+		if subtle.ConstantTimeCompare([]byte(ctx.Header("X-API-Key")), []byte(key)) != 1 {
 			_ = huma.WriteErr(api, ctx, http.StatusUnauthorized, "unauthorized")
 			return
 		}
@@ -67,7 +75,7 @@ func (app *App) httplogOptions() *httplog.Options {
 func (app *App) skipRequestLog(r *http.Request, _ int) bool {
 	route := chi.RouteContext(r.Context()).RoutePattern()
 	switch route {
-	case "/static/*", "/healthz", "/metrics":
+	case "/static/*", "/healthz":
 		return true
 	}
 {% if cookiecutter.use_river and not cookiecutter.api_only -%}

--- a/{{ cookiecutter.project_slug }}/internal/server/middleware_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/middleware_test.go
@@ -1,0 +1,75 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
+	"{{ cookiecutter.go_module_path.strip() }}/internal/server"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+)
+
+// guardedAPI puts one operation behind ApiKeyAuth, so a request either reaches
+// the handler or it does not. No database: the middleware reads only config.
+func guardedAPI(t *testing.T, apiKey string) humatest.TestAPI {
+	t.Helper()
+{% if cookiecutter.database_choice == 'postgres' -%}
+	t.Setenv("EMBEDDED_POSTGRES", "true")
+{% endif -%}
+{% if not cookiecutter.api_only -%}
+	t.Setenv("TRUSTED_ORIGINS", "https://trusted.example")
+{% endif -%}
+	t.Setenv("X_API_KEY", apiKey)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	app := &server.App{Deps: server.Deps{Conf: cfg}}
+	_, api := humatest.New(t, huma.DefaultConfig("test", "1.0.0"))
+	huma.Register(api, huma.Operation{
+		OperationID:   "guarded",
+		Method:        http.MethodGet,
+		Path:          "/guarded",
+		DefaultStatus: http.StatusOK,
+		Middlewares:   huma.Middlewares{app.ApiKeyAuth(api)},
+	}, func(context.Context, *struct{}) (*struct{}, error) { return nil, nil })
+
+	return api
+}
+
+// An unset key authorises nothing. Comparing an absent header against an empty
+// setting would otherwise admit every request that left the header off.
+func TestApiKeyAuthFailsClosedWhenUnset(t *testing.T) {
+	api := guardedAPI(t, "")
+
+	if res := api.Get("/guarded"); res.Code != http.StatusUnauthorized {
+		t.Errorf("no header: status = %d, want 401", res.Code)
+	}
+	if res := api.Get("/guarded", "X-API-Key: anything"); res.Code != http.StatusUnauthorized {
+		t.Errorf("with header: status = %d, want 401", res.Code)
+	}
+}
+
+func TestApiKeyAuthRejectsWrongKey(t *testing.T) {
+	api := guardedAPI(t, "correct-horse")
+
+	if res := api.Get("/guarded", "X-API-Key: wrong"); res.Code != http.StatusUnauthorized {
+		t.Errorf("wrong key: status = %d, want 401", res.Code)
+	}
+	if res := api.Get("/guarded"); res.Code != http.StatusUnauthorized {
+		t.Errorf("missing header: status = %d, want 401", res.Code)
+	}
+}
+
+func TestApiKeyAuthAcceptsCorrectKey(t *testing.T) {
+	api := guardedAPI(t, "correct-horse")
+
+	if res := api.Get("/guarded", "X-API-Key: correct-horse"); res.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.Code)
+	}
+}

--- a/{{ cookiecutter.project_slug }}/internal/server/routes.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes.go
@@ -4,13 +4,14 @@ import (
 {% if not cookiecutter.api_only -%}
 	"io/fs"
 {% endif -%}
+	"fmt"
 	"net/http"
-	"strings"
 
 {% if not cookiecutter.api_only -%}
 	"{{ cookiecutter.go_module_path.strip() }}/assets"
 	"{{ cookiecutter.go_module_path.strip() }}/internal/ui"
 {% endif -%}
+	"{{ cookiecutter.go_module_path.strip() }}/internal/config"
 	"{{ cookiecutter.go_module_path.strip() }}/internal/version"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -143,20 +144,24 @@ func (app *App) humaConfig() huma.Config {
 // is directly reachable, and the default records only the peer that actually
 // opened the connection.
 //
-// Load has already rejected an unusable source, so the remaining arm is remote.
+// Neither panic can fire from configuration -- Load parses the same value
+// through the same function -- so either one means a mode was added there and
+// not here, which is worth a boot failure rather than silently downgrading to
+// the peer address.
 func (app *App) clientIPMiddleware() func(http.Handler) http.Handler {
-	mode, arg, _ := strings.Cut(app.Conf.Server.ClientIPSource, ":")
-	switch mode {
-	case "header":
-		return middleware.ClientIPFromHeader(arg)
-	case "xff":
-		prefixes := strings.Split(arg, ",")
-		for i, prefix := range prefixes {
-			prefixes[i] = strings.TrimSpace(prefix)
-		}
-		return middleware.ClientIPFromXFF(prefixes...)
-	default:
+	source, err := config.ParseClientIPSource(app.Conf.Server.ClientIPSource)
+	if err != nil {
+		panic(fmt.Sprintf("server: %v", err))
+	}
+	switch source.Mode {
+	case config.ClientIPRemote:
 		return middleware.ClientIPFromRemoteAddr
+	case config.ClientIPHeader:
+		return middleware.ClientIPFromHeader(source.Header)
+	case config.ClientIPXFF:
+		return middleware.ClientIPFromXFF(source.Prefixes...)
+	default:
+		panic(fmt.Sprintf("server: CLIENT_IP_SOURCE mode %q has no middleware", source.Mode))
 	}
 }
 

--- a/{{ cookiecutter.project_slug }}/internal/server/routes.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 {% endif -%}
 	"net/http"
+	"strings"
 
 {% if not cookiecutter.api_only -%}
 	"{{ cookiecutter.go_module_path.strip() }}/assets"
@@ -31,12 +32,7 @@ import (
 func (app *App) Routes() http.Handler {
 	router := chi.NewMux()
 	router.Use(middleware.RequestID)
-	// The template cannot know which reverse proxies a generated deployment
-	// trusts. Never infer a client IP from forwarded headers by default: those
-	// headers are client-controlled when the app is directly reachable. A
-	// deployment behind a proxy must replace this with a specifically trusted
-	// ClientIPFromHeader or ClientIPFromXFF configuration.
-	router.Use(middleware.ClientIPFromRemoteAddr)
+	router.Use(app.clientIPMiddleware())
 	// Recoverer sits outside the access log purely as a backstop for httplog
 	// itself: httplog recovers handler panics first and logs them with the
 	// request and a stack trace, which Recoverer alone cannot do.
@@ -45,7 +41,6 @@ func (app *App) Routes() http.Handler {
 	router.Use(middleware.Compress(5))
 	router.Use(securityHeaders)
 	router.Use(app.Metrics.Middleware)
-	router.Handle("/metrics", app.Metrics.Handler())
 
 {% if not cookiecutter.api_only -%}
 	staticFS, err := fs.Sub(assets.EmbeddedFiles, "static")
@@ -142,17 +137,70 @@ func (app *App) humaConfig() huma.Config {
 	return cfg
 }
 
+// clientIPMiddleware resolves the caller's address the way CLIENT_IP_SOURCE
+// asks. Nothing is inferred from forwarded headers unless a deployment names
+// the hop it trusts: those headers are client-controlled whenever this process
+// is directly reachable, and the default records only the peer that actually
+// opened the connection.
+//
+// Load has already rejected an unusable source, so the remaining arm is remote.
+func (app *App) clientIPMiddleware() func(http.Handler) http.Handler {
+	mode, arg, _ := strings.Cut(app.Conf.Server.ClientIPSource, ":")
+	switch mode {
+	case "header":
+		return middleware.ClientIPFromHeader(arg)
+	case "xff":
+		prefixes := strings.Split(arg, ",")
+		for i, prefix := range prefixes {
+			prefixes[i] = strings.TrimSpace(prefix)
+		}
+		return middleware.ClientIPFromXFF(prefixes...)
+	default:
+		return middleware.ClientIPFromRemoteAddr
+	}
+}
+
 // securityHeaders: no-referrer keeps token-bearing URLs out of the Referer
 // header on any outbound navigation.
+//
+// Framing is refused twice over. huma serves its docs page with a
+// Content-Security-Policy of its own, and setting a header replaces rather
+// than appends, so the policy below is gone by the time /docs is written --
+// X-Frame-Options is what still covers that page.
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
+{% if not cookiecutter.api_only -%}
+		// A fuller policy is left to the application that grows here, because
+		// the useful one is not the obvious one: Datastar compiles every
+		// data-* expression with the Function constructor, which CSP counts as
+		// eval. Under a bare script-src 'self' the page still renders and then
+		// silently ignores every interaction.
+		//
+		//	default-src 'self'; script-src 'self' 'unsafe-eval';
+		//	style-src 'self' 'unsafe-inline'; frame-ancestors 'none'
+		//
+		// style-src covers the stylesheet inlined in layout.templ.
+{% endif -%}
 		next.ServeHTTP(w, r)
 	})
 }
 
 func (app *App) registerEndpoints(api huma.API) {
+	// Everything here is public. To protect an operation, name the scheme and
+	// attach the middleware; X_API_KEY then has to be set or it refuses every
+	// caller:
+	//
+	//	huma.Register(api, huma.Operation{
+	//		...
+	//		Security: []map[string][]string{
+	//			{"xApiKey": {}},
+	//		},
+	//		Middlewares: huma.Middlewares{app.ApiKeyAuth(api)},
+	//	}, app.handleThing)
 	huma.Register(api, huma.Operation{
 		OperationID:   "healthz",
 		Method:        http.MethodGet,

--- a/{{ cookiecutter.project_slug }}/internal/server/routes_test.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/routes_test.go
@@ -51,7 +51,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 func TestMonitoringEndpoints(t *testing.T) {
 	ts := newTestServer(t)
 
-	for _, path := range []string{"/healthz", "/version", "/metrics"} {
+	for _, path := range []string{"/healthz", "/version"} {
 		t.Run(path, func(t *testing.T) {
 			res, err := ts.Client().Get(ts.URL + path)
 			if err != nil {
@@ -61,16 +61,60 @@ func TestMonitoringEndpoints(t *testing.T) {
 			if res.StatusCode != http.StatusOK {
 				t.Errorf("status = %d, want 200", res.StatusCode)
 			}
-			if path == "/metrics" {
-				body, err := io.ReadAll(res.Body)
-				if err != nil {
-					t.Fatalf("read %s: %v", path, err)
-				}
-				if !strings.Contains(string(body), "go_goroutines") {
-					t.Error("/metrics does not expose Go runtime metrics")
-				}
+		})
+	}
+}
+
+// Metrics ride a listener of their own so the port carrying them can stay off
+// the public interface. Answering here would put process statistics and the
+// whole route table back in front of anyone who asks.
+func TestMetricsAreNotOnThePublicRouter(t *testing.T) {
+	ts := newTestServer(t)
+
+	res, err := ts.Client().Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("get /metrics: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", res.StatusCode)
+	}
+}
+
+// Two headers, not one: huma serves its docs page with a Content-Security-Policy
+// of its own and setting that header replaces ours, so X-Frame-Options is the
+// only framing protection /docs keeps.
+func TestFramingIsDenied(t *testing.T) {
+	ts := newTestServer(t)
+
+	for _, path := range []string{"/healthz", "/docs"} {
+		t.Run(path, func(t *testing.T) {
+			res, err := ts.Client().Get(ts.URL + path)
+			if err != nil {
+				t.Fatalf("get %s: %v", path, err)
+			}
+			defer res.Body.Close()
+
+			if got := res.Header.Get("X-Frame-Options"); got != "DENY" {
+				t.Errorf("X-Frame-Options = %q, want DENY", got)
 			}
 		})
+	}
+}
+
+func TestContentSecurityPolicyDeniesFrameAncestors(t *testing.T) {
+	ts := newTestServer(t)
+
+	res, err := ts.Client().Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("get /healthz: %v", err)
+	}
+	defer res.Body.Close()
+
+	got := res.Header.Get("Content-Security-Policy")
+	if !strings.Contains(got, "frame-ancestors 'none'") {
+		t.Errorf("Content-Security-Policy = %q, want frame-ancestors 'none'", got)
 	}
 }
 

--- a/{{ cookiecutter.project_slug }}/internal/server/server.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/server.go
@@ -91,15 +91,13 @@ func newSessionManager(d Deps) *scs.SessionManager {
 // answered with 404 rather than 403 so a probe cannot use the status code to
 // confirm that a resource exists.
 //
-// The panic below cannot fire from configuration: Load has already rejected
-// every origin this would refuse, so reaching it means the two have drifted
+// The panic cannot fire from configuration: Load builds this from the same
+// list through the same function, so reaching it means the two have drifted
 // apart.
 func newCrossOriginProtection(cfg *config.Conf) *http.CrossOriginProtection {
-	p := http.NewCrossOriginProtection()
-	for _, origin := range cfg.AppConf.TrustedOrigins {
-		if err := p.AddTrustedOrigin(origin); err != nil {
-			panic(fmt.Sprintf("server: invalid TRUSTED_ORIGINS entry %q: %v", origin, err))
-		}
+	p, problems := config.NewCrossOriginProtection(cfg.AppConf.TrustedOrigins)
+	if len(problems) > 0 {
+		panic(fmt.Sprintf("server: %v", problems))
 	}
 	p.SetDenyHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -124,47 +122,44 @@ func (app *App) Stop(ctx context.Context) error {
 {% endif -%}
 }
 
+// newHTTPServer builds a listener on port carrying the configured timeouts.
+func (app *App) newHTTPServer(port int, h http.Handler) *http.Server {
+	return &http.Server{
+		Addr:         fmt.Sprintf(":%d", port),
+		Handler:      h,
+		IdleTimeout:  app.Conf.Server.TimeoutIdle,
+		ReadTimeout:  app.Conf.Server.TimeoutRead,
+		WriteTimeout: app.Conf.Server.TimeoutWrite,
+	}
+}
+
+// listen serves srv until it is shut down. ErrServerClosed is what Shutdown
+// leaves behind, not a failure.
+func (app *App) listen(name string, srv *http.Server) func() error {
+	return func() error {
+		app.Log.Info(name+" listening", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	}
+}
+
 // Serve runs the HTTP server until a signal arrives or a goroutine fails,
 // then drains in-flight requests within shutdownGrace.
 func (app *App) Serve(ctx context.Context) error {
-	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", app.Conf.Server.Port),
-		Handler:      app.Routes(),
-		IdleTimeout:  app.Conf.Server.TimeoutIdle,
-		ReadTimeout:  app.Conf.Server.TimeoutRead,
-		WriteTimeout: app.Conf.Server.TimeoutWrite,
-	}
-
+	srv := app.newHTTPServer(app.Conf.Server.Port, app.Routes())
 	// A listener of its own, on a port nothing publishes: process statistics
 	// and the route table are worth handing an operator and no one else.
-	metricsSrv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", app.Conf.Server.MetricsPort),
-		Handler:      app.Metrics.Handler(),
-		IdleTimeout:  app.Conf.Server.TimeoutIdle,
-		ReadTimeout:  app.Conf.Server.TimeoutRead,
-		WriteTimeout: app.Conf.Server.TimeoutWrite,
-	}
+	metricsSrv := app.newHTTPServer(app.Conf.Server.MetricsPort, app.Metrics.Handler())
 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
-		app.Log.Info("HTTP server listening", "port", app.Conf.Server.Port)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return err
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		app.Log.Info("metrics server listening", "port", app.Conf.Server.MetricsPort)
-		if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return err
-		}
-		return nil
-	})
+	g.Go(app.listen("HTTP server", srv))
+	g.Go(app.listen("metrics server", metricsSrv))
 
 	g.Go(func() error {
 		<-gctx.Done()
@@ -174,12 +169,21 @@ func (app *App) Serve(ctx context.Context) error {
 		// requests this grace period exists to drain.
 		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownGrace)
 		defer cancel()
-		// Scrapes are short, so the metrics listener has nothing to drain and
-		// its failure to close is not worth failing the shutdown over.
-		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
-			app.Log.Error("metrics server shutdown", "error", err)
-		}
-		return srv.Shutdown(shutdownCtx)
+
+		// Together, not in turn: Shutdown blocks until its own listener has
+		// drained, so a metrics scrape that hangs would otherwise spend the
+		// grace period that in-flight requests exist to use.
+		var draining errgroup.Group
+		draining.Go(func() error {
+			// Scrapes are short, so the metrics listener has nothing to drain
+			// and its failure to close is not worth failing the shutdown over.
+			if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+				app.Log.Error("metrics server shutdown", "error", err)
+			}
+			return nil
+		})
+		draining.Go(func() error { return srv.Shutdown(shutdownCtx) })
+		return draining.Wait()
 	})
 
 	// A signal is the ordinary way to stop, so its cancellation is not an error.

--- a/{{ cookiecutter.project_slug }}/internal/server/server.go
+++ b/{{ cookiecutter.project_slug }}/internal/server/server.go
@@ -90,6 +90,10 @@ func newSessionManager(d Deps) *scs.SessionManager {
 // newCrossOriginProtection builds the stdlib CSRF check. A rejected request is
 // answered with 404 rather than 403 so a probe cannot use the status code to
 // confirm that a resource exists.
+//
+// The panic below cannot fire from configuration: Load has already rejected
+// every origin this would refuse, so reaching it means the two have drifted
+// apart.
 func newCrossOriginProtection(cfg *config.Conf) *http.CrossOriginProtection {
 	p := http.NewCrossOriginProtection()
 	for _, origin := range cfg.AppConf.TrustedOrigins {
@@ -131,6 +135,16 @@ func (app *App) Serve(ctx context.Context) error {
 		WriteTimeout: app.Conf.Server.TimeoutWrite,
 	}
 
+	// A listener of its own, on a port nothing publishes: process statistics
+	// and the route table are worth handing an operator and no one else.
+	metricsSrv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", app.Conf.Server.MetricsPort),
+		Handler:      app.Metrics.Handler(),
+		IdleTimeout:  app.Conf.Server.TimeoutIdle,
+		ReadTimeout:  app.Conf.Server.TimeoutRead,
+		WriteTimeout: app.Conf.Server.TimeoutWrite,
+	}
+
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -145,6 +159,14 @@ func (app *App) Serve(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
+		app.Log.Info("metrics server listening", "port", app.Conf.Server.MetricsPort)
+		if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	})
+
+	g.Go(func() error {
 		<-gctx.Done()
 		app.Log.Warn("shutting down", "addr", srv.Addr)
 		// WithoutCancel: gctx is already done by the time we get here, so a
@@ -152,6 +174,11 @@ func (app *App) Serve(ctx context.Context) error {
 		// requests this grace period exists to drain.
 		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownGrace)
 		defer cancel()
+		// Scrapes are short, so the metrics listener has nothing to drain and
+		// its failure to close is not worth failing the shutdown over.
+		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			app.Log.Error("metrics server shutdown", "error", err)
+		}
 		return srv.Shutdown(shutdownCtx)
 	})
 


### PR DESCRIPTION
A security review of the generated project found configuration advertising
protections that nothing implemented, plus one gate hardened everywhere except
a single path. Six findings, the two follow-on bugs they exposed, then a pass
over the duplication the fixes themselves left behind.

## Findings

| Was | Now |
|---|---|
| `RATE_LIMIT_*` shipped `Enabled=true`; nothing ever read `Conf.Limiter` | Deleted. Rate limiting belongs at the edge — behind a reverse proxy this binary sees the proxy's address, so an IP-keyed limiter here files every visitor into one bucket and lets the first busy client lock out the rest |
| `ApiKeyAuth` compared keys with `!=` | `subtle.ConstantTimeCompare`, and `registerEndpoints` now shows where the gate goes |
| `/metrics` public, unauthenticated, no way to switch it off | Its own listener on `METRICS_PORT`, which no Dockerfile exposes |
| Nothing stopped the UI being framed | `X-Frame-Options: DENY` and `frame-ancestors 'none'` |
| An invalid `TRUSTED_ORIGINS` entry panicked inside `New()` | Validated in `config.Load` and reported beside every other problem |
| Production refused to boot without `X_API_KEY` | Dropped. No operation consumed it, and `ApiKeyAuth` already fails closed on an empty key |

## Two bugs this uncovered

**`TRUSTED_ORIGINS` never worked with more than one origin.** `envdecode`
splits a plain `[]string` on semicolons, which is not the separator anyone
reaches for — and `.env.example` documented a comma. A second origin was
swallowed into the first and the pair rejected as one unparseable value, which
before this branch meant a panic at boot. `envdecode` prefers a
`TextUnmarshaler` over its own slice handling, so a named type takes the
decision back: the separator is now a comma, entries are trimmed, and every
reader still sees a `[]string`.

**A freshly generated project failed its own lint gate.** `.woodpecker.yml`
runs `golangci-lint` as a required step with the deploy gated behind it: 13
issues on the default variant, 14 with NATS, before the author wrote a line.
Now zero on every variant. `ci.yml` gained the same job pinned to the same
release, so the two CI choices can no longer disagree about whether code
passes.

## Added

`CLIENT_IP_SOURCE` — `remote`, `header:<Name>` or `xff:<cidr>`. The source was
hardcoded to `RemoteAddr`, so every access log line behind a proxy recorded the
proxy rather than the caller, and correcting it meant editing Go source.
Prefixes are validated during `Load` because chi builds them with
`netip.MustParsePrefix` and would otherwise take the process down at boot.

## Removed

`betteralign`, which made `task audit` fail on every generated project:
`-apply` exits 3 once it has applied a fix, so the task reported failure for
work that had succeeded, and did so again on each fresh checkout. `task audit`
now exits 0 and leaves the tree unmodified.

## Then: define each setting once

Each setting above ended up written twice — validated in `config.Load`, parsed
again where it was wired — with a comment holding the two copies together.

`CLIENT_IP_SOURCE` was the worst of it. Both `Load` and `clientIPMiddleware`
cut the mode off the front and split the CIDR list, and the middleware's
`default` arm mapped `remote` and anything unrecognised to the same
`ClientIPFromRemoteAddr`. A mode added to the validator and forgotten in the
router would not fail, or warn, or show up in a test — it would quietly log the
peer address, the weakest setting the option has. `ParseClientIPSource` now
owns the grammar, `Load` reports its error beside every other problem, and the
router wires the result with named modes and a panic on one it cannot handle.

`TRUSTED_ORIGINS` had the same shape, milder: `Load` built a
`CrossOriginProtection` purely to see what it refused, threw it away, and left
the server to build a second one that panicked on anything `Load` had missed.
Both now go through `config.NewCrossOriginProtection`.

One behaviour fix went with it. The metrics and request listeners drain
together now rather than in turn — `Shutdown` blocks until its own listener is
clear, and both shared one ten-second context, so a metrics scrape that hung
could spend the entire grace period in-flight requests exist to use, leaving
the real server shutting down against an expired deadline.

## Worth attention while reviewing

- **Both framing headers are load-bearing.** huma's docs handler calls
  `SetHeader("Content-Security-Policy", …)`, which replaces rather than
  appends, so the CSP set by `securityHeaders` is gone by the time `/docs` is
  written. `X-Frame-Options` is the only framing protection that page keeps.
- **No fuller CSP, deliberately.** Datastar compiles its `data-*` expressions
  with the `Function` constructor, which CSP counts as eval, so any
  `script-src` has to permit `'unsafe-eval'`. A working starting point sits in
  a comment rather than shipping a policy that looks stricter than it is.
- **`X_API_KEY` is optional everywhere now.** Nothing is protected by default;
  the middleware is a building block to attach once there is something worth
  guarding.
- **Removing the `X_API_KEY` production check emptied a branch.** Postgres and
  the UI supply every other check inside `if c.IsProduction()`, so a SQLite
  `api_only` build rendered it empty and tripped `SA9003` — a combination only
  the variant matrix catches. Rather than gate the shared block on a condition
  summarising the guards inside it, each check now carries its own
  `c.IsProduction() &&`. A later check that happened not to be conditional on
  Postgres or the UI would otherwise have compiled, passed every combination,
  and been silently absent from one of them.
- **An unusable `CLIENT_IP_SOURCE` now panics rather than falling back.**
  `Load` always supplies a mode, so this is unreachable in a running process —
  but a hand-built `config.Conf{}` passed to `Routes()` will panic where it
  previously used `RemoteAddr`. That is the intent: silently downgrading the
  setting is the failure worth making loud.
- **`originList` parses `TRUSTED_ORIGINS` itself.** Worth a look if you would
  rather keep decoding entirely inside `envdecode`; the trade is that its
  separator cannot be changed.

## Known gap

A malformed `xff:` chain resolves to no address at all — chi fails closed
rather than trusting a less-trusted entry — and the access logger substitutes
`r.RemoteAddr` for an empty result. The line then shows the proxy, with nothing
to distinguish it from never having configured the setting. Not addressed here;
the docs do not mention it yet.

Checked across postgres, sqlite, `api_only`, tailwind+pwa and nats variants:
generation, `task init`, build, `go vet`, gofmt, `golangci-lint` and the full
test suite pass on all seven combinations.
