### PR TITLE
Build Docker tools on native platform

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.postgres
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.postgres
@@ -3,7 +3,9 @@
 # false-positives on Dockerfiles, silently shipping an unrendered template. So
 # nothing here is templated — the binary is always installed as /usr/bin/app,
 # and the single main package under ./cmd is found by wildcard.
-FROM ghcr.io/danielmichaels/ci-toolkit:latest AS builder
+# Build tools (Tailwind, templ, and the Go compiler) run natively even when
+# buildx is producing an image for another architecture.
+FROM --platform=$BUILDPLATFORM ghcr.io/danielmichaels/ci-toolkit:latest AS builder
 
 WORKDIR /build
 
@@ -27,7 +29,10 @@ RUN if ls ./internal/ui/templates/*.templ >/dev/null 2>&1; then templ generate; 
 ARG VERSION=dev
 ARG REVISION=unknown
 
-ENV CGO_ENABLED=0 GOOS=linux
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=${TARGETARCH}
 
 # The module path comes from go.mod rather than being baked in, so the ldflags
 # stay correct if the module is ever renamed.

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.sqlite
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.sqlite
@@ -4,7 +4,9 @@
 # nothing here is templated — the binary is always installed as /usr/bin/app,
 # and the single main package under ./cmd is found by wildcard.
 FROM litestream/litestream:0.5.9 AS litestream
-FROM ghcr.io/danielmichaels/ci-toolkit:latest AS builder
+# Build tools (Tailwind, templ, and the Go compiler) run natively even when
+# buildx is producing an image for another architecture.
+FROM --platform=$BUILDPLATFORM ghcr.io/danielmichaels/ci-toolkit:latest AS builder
 
 WORKDIR /build
 
@@ -28,7 +30,10 @@ RUN if ls ./internal/ui/templates/*.templ >/dev/null 2>&1; then templ generate; 
 ARG VERSION=dev
 ARG REVISION=unknown
 
-ENV CGO_ENABLED=0 GOOS=linux
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=${TARGETARCH}
 
 # The module path comes from go.mod rather than being baked in, so the ldflags
 # stay correct if the module is ever renamed.


### PR DESCRIPTION
## Summary

Resolves #22 by keeping the Docker builder stage on `$BUILDPLATFORM` and cross-compiling the Go binary for `$TARGETARCH`.

## Changes

- Run ci-toolkit natively for both Postgres and SQLite Dockerfiles.
- Set `GOOS=linux` and `GOARCH=$TARGETARCH` for the application build.
- Preserve multi-platform amd64/arm64 output images while avoiding QEMU for Tailwind, templ, and Go build steps.